### PR TITLE
refactor: Improve Ollama integration and add Ollama URL option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.3.0] - 2025-03-15
+## [0.3.0] - 2025-03-17
 
-Codebase refactoring and improvements.
+Complete codebase refactoring and improvements.
 
 ### Added
 - Added support for new vulnerability types (RCE, SSRF, XXE, Path Traversal, IDOR, CSRF)
@@ -10,8 +10,11 @@ Codebase refactoring and improvements.
 - Added HTML template and CSS styling for better report readability
 - Added better emoji support in logging for better readability
 - Added more comprehensive test files with vulnerability examples
+- Added support for custom Ollama URL
 
 ### Changed
+- Improved codebase organization and readability
+- Improved embedding and analysis process
 - Improved cache management with dedicated .oasis_cache/ directory
 - Enhanced logging system with custom EmojiFormatter
 - Improved report generation with better styling and formatting
@@ -21,14 +24,26 @@ Codebase refactoring and improvements.
 ### Fixed
 - Fixed embeddings cache storage and validation
 - Fixed report rendering with proper page breaks
+- Fixed issue with model installation progress tracking
+- Fixed issue with cache saving during interruption
+- Fixed issue with model availability check
+- Fixed issue with progress bar updates
+- Fixed issue with log message formatting
 
 ### Technical
 - Added configuration constants for better maintainability
 - Added Jinja2 templating for report generation
 - Implemented normalized heading levels in reports
+- Improved error handling and logging
 
 ### Documentation
 - Enhanced code documentation with proper docstrings
+- Added more comprehensive README with examples and usage instructions
+- Improved command line interface documentation
+- Added more detailed changelog
+- Updated project structure documentation
+- Added more comprehensive code comments
+- Improved code readability and maintainability
 
 ## [0.2.0] - 2025-01-29
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ oasis --input-path [path_to_analyze] \
 - `--clear-cache` `-cc`: Clear embeddings cache before starting
 - `--audit` `-a`: Run embedding distribution analysis
 - `--chunk-size` `-ch`: Maximum chunk size for splitting content (default: auto-detect)
+- `--ollama-url` `-ol`: Ollama URL (default: http://localhost:11434)
 
 ### 🛡️ Supported Vulnerability Types
 

--- a/oasis/analyze.py
+++ b/oasis/analyze.py
@@ -14,7 +14,7 @@ from .report import Report
 from .embedding import EmbeddingManager, build_vulnerability_embedding_prompt
 
 class SecurityAnalyzer:
-    def __init__(self, llm_model: str, embedding_manager: EmbeddingManager):
+    def __init__(self, llm_model: str, embedding_manager: EmbeddingManager, ollama_manager: OllamaManager):
         """
         Initialize the security analyzer
 
@@ -23,7 +23,7 @@ class SecurityAnalyzer:
             embedding_manager: Embedding manager to use for embeddings
         """
         try:
-            self.ollama_manager = OllamaManager()
+            self.ollama_manager = ollama_manager
             self.client = self.ollama_manager.get_client()
         except Exception as e:
             logger.error("Failed to initialize Ollama client")
@@ -366,14 +366,14 @@ class EmbeddingAnalyzer:
         embedding_manager: Initialized EmbeddingManager
     """
     
-    def __init__(self, embedding_manager):
+    def __init__(self, embedding_manager: EmbeddingManager, ollama_manager: OllamaManager):
         """
         Initialize the embedding analyzer
         
         Args:
             embedding_manager: Initialized EmbeddingManager
         """
-        self.ollama_manager = OllamaManager()
+        self.ollama_manager = ollama_manager
         self.embedding_manager = embedding_manager
         self.code_base = embedding_manager.code_base
         self.embedding_model = embedding_manager.embedding_model
@@ -577,6 +577,7 @@ class EmbeddingAnalyzer:
         common_args = {
             "vulnerability": vuln,
             "embedding_model": self.embedding_model,
+            "api_url": self.ollama_manager.api_url
         }
         
         # Process each element based on analysis mode
@@ -678,7 +679,7 @@ def analyze_item_parallel(args: tuple) -> Dict:
     """
     try:
         # Create a new Ollama client for each process
-        client = OllamaManager().get_client()
+        client = OllamaManager(args.api_url).get_client()
         
         # Build vulnerability embedding prompt directly
         vuln_data = args.vulnerability

--- a/oasis/config.py
+++ b/oasis/config.py
@@ -93,7 +93,7 @@ MAX_CHUNK_SIZE = 2048
 EMBEDDING_THRESHOLDS = [0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
 # Ollama API endpoint
-OLLAMA_API_URL = "http://localhost:11434"
+OLLAMA_URL = "http://localhost:11434"
 
 # Models configuration
 EXCLUDED_MODELS = [

--- a/oasis/embedding.py
+++ b/oasis/embedding.py
@@ -941,6 +941,9 @@ def generate_content_embedding(content: str, model: str, chunk_size: int = DEFAU
     Returns:
         Embedding vector as list of floats, aggregated if content was chunked
     """
+    if ollama_manager is None:
+        raise ValueError("ollama_manager must be provided and cannot be None")
+
     try:
         client = ollama_manager.get_client()
 
@@ -981,6 +984,9 @@ def extract_functions_from_file(file_path: str, content: str, extraction_model: 
     Returns:
         Dictionary mapping function IDs to function content
     """
+    if ollama_manager is None:
+        raise ValueError("ollama_manager must be provided")
+
     # Determine file extension
     extension = file_path.split('.')[-1].lower()
     

--- a/oasis/embedding.py
+++ b/oasis/embedding.py
@@ -1,5 +1,4 @@
 import argparse
-import itertools
 import json
 from pathlib import Path
 import pickle
@@ -18,7 +17,7 @@ from .ollama_manager import OllamaManager
 from .tools import logger, chunk_content, parse_input, sanitize_name, open_file
 
 class EmbeddingManager:
-    def __init__(self, args):
+    def __init__(self, args, ollama_manager: OllamaManager):
         """
         Initialize the embedding manager
 
@@ -26,7 +25,7 @@ class EmbeddingManager:
             args: Arguments
         """
         try:
-            self.ollama_manager = OllamaManager()
+            self.ollama_manager = ollama_manager
             self.ollama_client = self.ollama_manager.get_client()
 
         except Exception as e:
@@ -127,6 +126,7 @@ class EmbeddingManager:
                     embed_model=self.embedding_model,
                     chunk_size=self.chunk_size,
                     analyze_by_function=self.analyze_by_function,
+                    api_url=self.ollama_manager.api_url
                 )
                 for file_path in files 
                 if self.analyze_by_function or str(file_path) not in self.code_base
@@ -847,6 +847,9 @@ def process_file_parallel(args: tuple) -> Tuple[str, str, List[float], bool, Opt
         Tuple of (file_path, content, embedding, is_function_analysis, function_embeddings)
     """
     try:
+        # Create a new Ollama client for each process
+        ollama_manager = OllamaManager(args.api_url)
+
         # Read file content
         if not (content := open_file(args.input_path)):
             logger.warning(f"Empty or unreadable file content for file: {args.input_path}")
@@ -855,7 +858,7 @@ def process_file_parallel(args: tuple) -> Tuple[str, str, List[float], bool, Opt
         # Extract embeddings based on analysis type
         if args.analyze_by_function:
             # Extract functions
-            functions = extract_functions_from_file(args.input_path, content)
+            functions = extract_functions_from_file(args.input_path, content, ollama_manager)
             
             # Generate embeddings for functions
             function_embeddings = {}
@@ -863,7 +866,8 @@ def process_file_parallel(args: tuple) -> Tuple[str, str, List[float], bool, Opt
                 func_embedding = generate_content_embedding(
                     func_content, 
                     args.embed_model, 
-                    args.chunk_size
+                    args.chunk_size,
+                    ollama_manager
                 )
                 if func_embedding is not None:
                     function_embeddings[func_id] = (func_content, func_embedding)
@@ -872,7 +876,8 @@ def process_file_parallel(args: tuple) -> Tuple[str, str, List[float], bool, Opt
             file_embedding = generate_content_embedding(
                 content, 
                 args.embed_model, 
-                args.chunk_size
+                args.chunk_size,
+                ollama_manager
             )
             if file_embedding is not None:
                 return args.input_path, content, file_embedding, True, function_embeddings
@@ -881,7 +886,8 @@ def process_file_parallel(args: tuple) -> Tuple[str, str, List[float], bool, Opt
             file_embedding = generate_content_embedding(
                 content, 
                 args.embed_model, 
-                args.chunk_size
+                args.chunk_size,
+                ollama_manager
             )
             if file_embedding is not None:
                 return args.input_path, content, file_embedding, False, None
@@ -923,7 +929,7 @@ def build_vulnerability_embedding_prompt(vulnerability: Union[str, Dict]) -> str
     else:
         # Use the string directly
         return str(vulnerability)
-def generate_content_embedding(content: str, model: str, chunk_size: int = DEFAULT_ARGS['CHUNK_SIZE']) -> List[float]:
+def generate_content_embedding(content: str, model: str, chunk_size: int = DEFAULT_ARGS['CHUNK_SIZE'], ollama_manager: OllamaManager = None) -> List[float]:
     """
     Generate embedding for content
 
@@ -936,7 +942,7 @@ def generate_content_embedding(content: str, model: str, chunk_size: int = DEFAU
         Embedding vector as list of floats, aggregated if content was chunked
     """
     try:
-        client = OllamaManager().get_client()
+        client = ollama_manager.get_client()
 
         # For large content, chunk and get embeddings for each chunk
         if len(content) > chunk_size:
@@ -963,7 +969,7 @@ def generate_content_embedding(content: str, model: str, chunk_size: int = DEFAU
         logger.exception(f"Error generating embedding: {str(e)}")
         return None
 
-def extract_functions_from_file(file_path: str, content: str, extraction_model: str = EXTRACT_FUNCTIONS['MODEL']) -> Dict[str, str]:
+def extract_functions_from_file(file_path: str, content: str, extraction_model: str = EXTRACT_FUNCTIONS['MODEL'], ollama_manager: OllamaManager = None) -> Dict[str, str]:
     """
     Extract functions from file content
     
@@ -983,10 +989,9 @@ def extract_functions_from_file(file_path: str, content: str, extraction_model: 
     
     try:
         # Get client 
-        client = OllamaManager().get_client()
+        client = ollama_manager.get_client()
         
         # Ensure model is available
-        ollama_manager = OllamaManager()
         if not ollama_manager.ensure_model_available(extraction_model):
             return {}
             

--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -188,7 +188,7 @@ class OasisScanner:
                 return 1  # Error exit code for validation failures
 
             # Initialize Ollama and check connection
-            if not self._init_ollama():
+            if not self._init_ollama(self.args.ollama_url):
                 return 1
 
             # Process input files and initialize report
@@ -246,15 +246,19 @@ class OasisScanner:
         display_logo()
         return True
 
-    def _init_ollama(self, check_embeddings=True):
+    def _init_ollama(self, ollama_url=None, check_embeddings=True):
         """
         Initialize Ollama and check connections
 
+        Args:
+            check_embeddings: Whether to check if embeddings are available
         Returns:
             True if Ollama is running and connected, False otherwise
         """
         # Initialize Ollama manager
-        self.ollama_manager = OllamaManager(self.args.ollama_url)
+        if ollama_url is None:
+            ollama_url = self.args.ollama_url
+        self.ollama_manager = OllamaManager(ollama_url)
 
         if self.ollama_manager.get_client() is None:
             logger.error("Ollama is not running. Please start Ollama and try again.")
@@ -382,7 +386,7 @@ class OasisScanner:
             False: Error occurred, program should exit with error code
         """
         try:
-            self._init_ollama(check_embeddings=False)
+            self._init_ollama(self.args.ollama_url, check_embeddings=False)
                 
             logger.info("🔎 Querying available models from Ollama...")
             


### PR DESCRIPTION
Fix #8 
This change refactors the Ollama integration to improve performance and adds an option to specify the Ollama URL. The Ollama client is now initialized once and reused, and a new client is created for each process in parallel operations. An --ollama-url argument has been added to the CLI to allow users to specify the URL of their Ollama instance. Additionally, log messages related to Ollama connection have been improved.