### PR TITLE
fix for `-at deep`

### DIFF
--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -157,9 +157,17 @@ class OasisScanner:
         logger.info(f"\nStarting security analysis at {generate_timestamp()}\n")
         start_time = time.time()
         
-        # Determine analysis type (adaptive or standard)
+        # Determine analysis type
         adaptive = hasattr(self.args, 'adaptive') and self.args.adaptive
-        analysis_type = "🧠 adaptive" if adaptive else "📋 standard"
+        analyze_type = getattr(self.args, 'analyze_type', 'standard')
+        
+        if adaptive:
+            analysis_type = "🧠 adaptive"
+        elif analyze_type == 'deep':
+            analysis_type = "🔥 deep (skip scan)"
+        else:
+            analysis_type = "📋 standard (scan + deep)"
+            
         logger.info(f"Using {analysis_type} analysis mode")
 
         # Process all main models one by one

--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -11,7 +11,7 @@ from typing import Union
 from .config import MODEL_EMOJIS, REPORT, DEFAULT_ARGS
 
 # Import from other modules
-from .tools import generate_timestamp, setup_logging, logger, display_logo, get_vulnerability_mapping
+from .tools import generate_timestamp, setup_logging, logger, display_logo, get_vulnerability_mapping, _should_disable_progress
 from .ollama_manager import OllamaManager
 from .embedding import EmbeddingManager
 from .analyze import SecurityAnalyzer, EmbeddingAnalyzer
@@ -107,6 +107,8 @@ class OasisScanner:
                                 help='Enable debug output')
         logging_group.add_argument('-s', '--silent', action='store_true',
                                 help='Disable all output messages')
+        logging_group.add_argument('--no-progress', action='store_true',
+                                help='Disable the output of the progress bars')
         
         # Special Modes
         special_group = parser.add_argument_group('Special Modes')
@@ -374,7 +376,7 @@ class OasisScanner:
             return False
 
         # Check embedding model availability
-        return bool(self.ollama_manager.ensure_model_available(self.args.embed_model))
+        return bool(self.ollama_manager.ensure_model_available(self.args.embed_model, _should_disable_progress(self.args)))
 
     def _init_processing(self):
         """
@@ -420,7 +422,7 @@ class OasisScanner:
             return 1
 
         # Get available models
-        available_models = self.ollama_manager.get_available_models()
+        available_models = self.ollama_manager.get_available_models(disable_progress=_should_disable_progress(self.args))
         if not available_models:
             logger.error("No models available. Please check Ollama installation.")
             return 1
@@ -516,7 +518,7 @@ class OasisScanner:
             logger.info("🔎 Querying available models from Ollama...")
             
             # Display formatted list of models
-            available_models = self.ollama_manager.get_available_models(show_formatted=True)
+            available_models = self.ollama_manager.get_available_models(show_formatted=True, disable_progress=_should_disable_progress(self.args))
             
             if not available_models:
                 logger.error("No models available. Please check your Ollama installation.")

--- a/oasis/tools.py
+++ b/oasis/tools.py
@@ -12,6 +12,21 @@ from .config import KEYWORD_LISTS, MODEL_EMOJIS, VULNERABILITY_MAPPING
 # Initialize logger with module name
 logger = logging.getLogger('oasis')
 
+def _should_disable_progress(args=None, silent=False):
+    """
+    Utility function to determine if progress bars should be disabled
+    
+    Args:
+        args: Arguments object (optional)
+        silent: Silent flag (optional, for backward compatibility)
+        
+    Returns:
+        bool: True if progress bars should be disabled
+    """
+    if args:
+        return getattr(args, 'silent', False) or getattr(args, 'no_progress', False)
+    return silent
+
 # Suppress weasyprint warnings
 logging.getLogger('weasyprint').setLevel(logging.ERROR)
 


### PR DESCRIPTION
Hi,

Cool software !

I couldn't validate a basic RCE, and noticed that there were some things pending to do for `-at deep` to work as expected for this command:

```
mkdir tmp; cd tmp; echo 'import os,sys;os.system("ls "+sys.argv[1])'>test.py; ls -la; oasis -i ./ -m gpt-oss:20b -sm gpt-oss:20b -v rce -t 0.0 -at deep
```

<img width="1720" height="469" alt="Screenshot 2025-08-19 at 7 14 50 PM" src="https://github.com/user-attachments/assets/d8e35325-9bf2-4110-800e-042ce04f8acb" />

This fix will now allow that command to execute successfully. Feel free to modify or remove whatever is not required from this PR proposal.

Cheers!

## Summary by Sourcery

Introduce a new deep analysis mode that bypasses the lightweight scan and processes all files directly, add argument handling for analyze_type, implement the deep-only analysis workflow, and enhance logging and prompt instructions to support the new mode

New Features:
- Add deep-only analysis mode triggered by the -at deep flag to skip the initial scanning phase
- Introduce analyze_type argument for selecting the analysis workflow
- Implement _perform_deep_only_analysis to directly analyze all files and code chunks

Enhancements:
- Update run_analysis_mode logging to include a distinct label for deep analysis
- Refine common vulnerability prompt wording for entry points and HTTP methods