### PR TITLE
feat(ai): add cursor rules and skills & add thinking params

### DIFF
--- a/.cursor/rules/git-history-conventions.mdc
+++ b/.cursor/rules/git-history-conventions.mdc
@@ -1,0 +1,12 @@
+---
+description: Commit and release conventions inferred from OASIS history
+alwaysApply: true
+---
+
+# OASIS Git Conventions
+
+- Use Conventional Commit prefixes seen in history: `feat`, `fix`, `refactor`, `docs`, `release`, `version`.
+- Keep commit subjects short and scoped to user-visible intent (why), not low-level implementation detail.
+- For release-oriented changes, keep version, changelog, and docs aligned in the same working session.
+- When a CLI flag or behavior changes, update `README.md` in the same change to avoid drift.
+- Prefer incremental commits focused on one concern (e.g., caching, web UI bugfixes, model integration).

--- a/.cursor/rules/oasis-dashboard-js-patterns.mdc
+++ b/.cursor/rules/oasis-dashboard-js-patterns.mdc
@@ -1,0 +1,13 @@
+---
+description: Dashboard JavaScript patterns inferred from web UI bugfix commits
+globs: oasis/static/js/dashboard/**/*.js
+alwaysApply: false
+---
+
+# OASIS Dashboard JS Patterns
+
+- Keep dashboard code modular by concern (`api`, `filters`, `interactions`, `modal`, `views`, `utils`).
+- Extend the shared `DashboardApp` namespace instead of introducing parallel globals.
+- Centralize formatting and display helpers in utility modules to avoid duplicated logic.
+- When fixing UI bugs, update both interaction scripts and matching templates if the issue spans behavior and markup.
+- Prefer compatibility-safe fixes that preserve existing dashboard data contracts (`report` fields and optional defaults).

--- a/.cursor/rules/oasis-python-architecture.mdc
+++ b/.cursor/rules/oasis-python-architecture.mdc
@@ -1,0 +1,13 @@
+---
+description: Python implementation patterns inferred from OASIS refactor commits
+globs: oasis/**/*.py
+alwaysApply: false
+---
+
+# OASIS Python Architecture
+
+- Keep responsibilities split by module: orchestration in `oasis/oasis.py`, analysis in `oasis/analyze.py`, model lifecycle in `oasis/ollama_manager.py`, and shared utilities in dedicated helper modules.
+- Favor small manager/service classes over monolithic procedural flows when adding features.
+- Preserve CLI backward compatibility when possible (short and long flags); if a rename is required, mirror it in docs.
+- Route logs through centralized project logging helpers; avoid ad-hoc print statements in production paths.
+- For resilience changes (cache, network/model calls), prefer defensive fallbacks and explicit error handling.

--- a/.cursor/skills/oasis-implementation-patterns/SKILL.md
+++ b/.cursor/skills/oasis-implementation-patterns/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: oasis-implementation-patterns
+description: Implement OASIS features with patterns used in commit history. Use when modifying scanner flow, analysis, model integration, caching, CLI flags, or dashboard behavior.
+---
+
+# OASIS Implementation Patterns
+
+## Goal
+
+Apply the code organization and delivery style repeatedly used in OASIS commits.
+
+## Workflow
+
+1. Classify the change as `feat`, `fix`, or `refactor`.
+2. Identify the bounded module(s) to touch instead of editing a single large file:
+   - `oasis/oasis.py`: CLI and orchestration
+   - `oasis/analyze.py`: analysis logic
+   - `oasis/ollama_manager.py`: model and Ollama interactions
+   - `oasis/static/js/dashboard/*`: web dashboard behavior
+3. Keep interfaces compatible unless migration is explicit.
+4. Update docs (`README.md`) when user-facing flags or behavior change.
+5. Prefer defensive handling around cache/model/network boundaries.
+
+## Design Guardrails
+
+- Use KISS: choose the smallest change that solves the issue.
+- Use DRY: extract repeated formatting or parsing helpers.
+- Use SOLID: isolate responsibilities and avoid growing god functions.
+- Keep UX fixes localized for dashboard modules and templates.
+
+## Done Criteria
+
+- No obvious module boundary violation.
+- Any CLI option change is documented.
+- Change intent can be summarized with a conventional commit subject.

--- a/.cursor/skills/oasis-release-guardrails/SKILL.md
+++ b/.cursor/skills/oasis-release-guardrails/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: oasis-release-guardrails
+description: Prepare OASIS release-aligned changes based on historical release/version commits. Use when shipping versions, changelog updates, or user-facing CLI/documentation changes.
+---
+
+# OASIS Release Guardrails
+
+## Goal
+
+Keep release changes coherent across code, docs, and metadata like historical `release` and `version` commits.
+
+## Checklist
+
+- [ ] Confirm impact scope (`fix` only, feature, or release candidate).
+- [ ] If version changes, update authoritative version files consistently.
+- [ ] Update `CHANGELOG.md` for user-visible behavior changes.
+- [ ] Verify `README.md` reflects CLI options and workflow changes.
+- [ ] Ensure dashboard/web changes include matching template/assets updates when required.
+
+## Commit Guidance
+
+- Use `release: vX.Y.Z` for release batches.
+- Use `version: bump to X.Y.Z` for isolated version metadata updates.
+- Use `fix|feat|refactor|docs` for normal non-release changes.
+
+## Quality Gate
+
+Before finalizing:
+
+1. Re-read changed docs and confirm they match actual CLI/runtime behavior.
+2. Confirm no stale option name remains after renames.
+3. Ensure change grouping is logical (avoid mixing unrelated concerns).

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ oasis -i [path_to_analyze] -sm gemma3:4b -m llama3:latest,codellama:lates -t 0.7
 ### Model Selection
 - `--models` `-m`: Comma-separated list of models to use for deep analysis
 - `--scan-model` `-sm`: Model to use for quick scanning (default: same as main model)
+- `--model-thinking` `-mt`: Enable/disable thinking for deep analysis models [yes,no] (default: no)
+- `--small-model-thinking` `-smt`: Enable/disable thinking for the quick scan model [yes,no] (default: no)
 - `--embed-model` `-em`: Model to use for embeddings (default: nomic-embed-text:latest)
 - `--list-models` `-lm`: List available models and exit
 

--- a/oasis/analyze.py
+++ b/oasis/analyze.py
@@ -179,7 +179,7 @@ Analyze this code segment ({i + 1}/{total_chunks}) for {vuln_name} vulnerabiliti
             logger.debug(f"Analyzing chunk with {model_display}")
 
             # Make the API call with timeout
-            response = self.client.chat(
+            response = self.ollama_manager.chat(
                 model=model,
                 messages=[{'role': 'user', 'content': prompt}],
                 options={"timeout": timeout * 1000}  # Convert to milliseconds if API supports it

--- a/oasis/embedding.py
+++ b/oasis/embedding.py
@@ -754,11 +754,8 @@ class EmbeddingManager:
             """
 
         try:
-            # Get client from existing function
-            client = self.ollama_client
-
             # Generate response with a short context model
-            response = client.generate(
+            response = self.ollama_manager.generate(
                 model=extraction_model,
                 prompt=prompt,
             )
@@ -994,9 +991,6 @@ def extract_functions_from_file(file_path: str, content: str, extraction_model: 
     normalized_content = content.replace('\r\n', '\n')
     
     try:
-        # Get client 
-        client = ollama_manager.get_client()
-        
         # Ensure model is available
         if not ollama_manager.ensure_model_available(extraction_model):
             return {}
@@ -1012,7 +1006,7 @@ def extract_functions_from_file(file_path: str, content: str, extraction_model: 
             """
             
         # Generate response
-        response = client.generate(
+        response = ollama_manager.generate(
             model=extraction_model,
             prompt=prompt,
         )

--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -28,6 +28,24 @@ class OasisScanner:
         self.embedding_manager = None
         self.output_dir = None
 
+    @staticmethod
+    def _parse_yes_no_flag(value: str) -> bool:
+        """
+        Parse yes/no CLI values into booleans.
+
+        Args:
+            value: String value provided by user
+
+        Returns:
+            True for yes, False for no
+        """
+        normalized_value = value.strip().lower()
+        if normalized_value == "yes":
+            return True
+        if normalized_value == "no":
+            return False
+        raise argparse.ArgumentTypeError("Expected 'yes' or 'no'")
+
     def setup_argument_parser(self):
         """
         Configure and return argument parser
@@ -76,6 +94,10 @@ class OasisScanner:
                                 help='Comma-separated list of models to use (bypasses interactive selection - use `all` to use all models)')
         model_group.add_argument('-sm', '--scan-model', dest='scan_model', type=str,
                                 help='Model to use for quick scanning (default: same as main model)')
+        model_group.add_argument('-mt', '--model-thinking', dest='model_thinking', type=self._parse_yes_no_flag, default=False, metavar='yes|no',
+                                help='Enable/disable thinking for deep analysis models [yes,no] (default: no)')
+        model_group.add_argument('-smt', '--small-model-thinking', dest='small_model_thinking', type=self._parse_yes_no_flag, default=False, metavar='yes|no',
+                                help='Enable/disable thinking for the quick scan model [yes,no] (default: no)')
         model_group.add_argument('-em', '--embed-model', type=str, default=DEFAULT_ARGS['EMBED_MODEL'],
                                 help=f'Model to use for embeddings (default: {DEFAULT_ARGS["EMBED_MODEL"]})')
         model_group.add_argument('-lm', '--list-models', action='store_true',
@@ -444,6 +466,20 @@ class OasisScanner:
             logger.info(f"{MODEL_EMOJIS['default']}Using '{display_scan_model}' for both scanning and deep analysis")
         else:
             logger.info(f"{MODEL_EMOJIS['default']}Using '{display_scan_model}' for scanning and {display_main_models} for deep analysis")
+
+        self.ollama_manager.configure_analysis_model_thinking(
+            scan_model=scan_model,
+            main_models=main_models,
+            scan_model_thinking=self.args.small_model_thinking,
+            main_model_thinking=self.args.model_thinking
+        )
+        if scan_model in main_models and self.args.small_model_thinking != self.args.model_thinking:
+            logger.warning(
+                "Scan and deep analysis share the same model; applying deep analysis thinking setting for that model."
+            )
+        logger.info(
+            f"{MODEL_EMOJIS['default']}Model thinking: scan={self.args.small_model_thinking}, deep={self.args.model_thinking}"
+        )
         
         # Create the report directories for all main models
         self.report.models = main_models

--- a/oasis/ollama_manager.py
+++ b/oasis/ollama_manager.py
@@ -1,7 +1,7 @@
 import contextlib
 import threading
 import ollama
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 from tqdm import tqdm
 import logging
 
@@ -35,6 +35,7 @@ class OllamaManager:
         self.formatted_models = []
         # Cache for storing model information to avoid repeated API calls
         self._model_info_cache = {}
+        self._model_thinking_overrides: Dict[str, bool] = {}
     
     def get_client(self) -> ollama.Client:
         """
@@ -69,6 +70,109 @@ class OllamaManager:
             return True
         except ConnectionError:
             return False
+
+    def set_model_thinking(self, model: str, thinking: bool) -> None:
+        """
+        Set thinking behavior override for a given model.
+
+        Args:
+            model: Model name
+            thinking: Whether thinking is enabled for this model
+        """
+        self._model_thinking_overrides[model] = thinking
+
+    def configure_analysis_model_thinking(
+        self,
+        scan_model: str,
+        main_models: List[str],
+        scan_model_thinking: bool,
+        main_model_thinking: bool
+    ) -> None:
+        """
+        Configure thinking behavior for selected scan and deep analysis models.
+
+        Args:
+            scan_model: Model used for quick scanning
+            main_models: Models used for deep analysis
+            scan_model_thinking: Thinking flag for scan model
+            main_model_thinking: Thinking flag for deep models
+        """
+        if scan_model:
+            self.set_model_thinking(scan_model, scan_model_thinking)
+        for model in main_models or []:
+            self.set_model_thinking(model, main_model_thinking)
+
+    def _resolve_model_thinking(self, model: str) -> Optional[bool]:
+        """
+        Resolve whether thinking should be sent for a model.
+
+        Args:
+            model: Model name
+
+        Returns:
+            Thinking override, or None if no override is configured
+        """
+        return self._model_thinking_overrides.get(model)
+
+    def chat(self, model: str, messages: List[dict], options: Optional[dict] = None, **kwargs):
+        """
+        Chat completion wrapper with per-model thinking support.
+        """
+        client = self.get_client()
+        request_kwargs = {
+            "model": model,
+            "messages": messages
+        }
+        if options is not None:
+            request_kwargs["options"] = options
+        request_kwargs.update(kwargs)
+
+        thinking = self._resolve_model_thinking(model)
+        if thinking is not None:
+            request_kwargs["think"] = thinking
+
+        try:
+            return client.chat(**request_kwargs)
+        except TypeError as error:
+            # Backward compatibility with ollama clients not supporting think=
+            error_message = error.args[0] if error.args else ""
+            if (
+                "think" in request_kwargs
+                and "unexpected keyword argument 'think'" in str(error_message)
+            ):
+                request_kwargs.pop("think", None)
+                return client.chat(**request_kwargs)
+            raise
+
+    def generate(self, model: str, prompt: str, options: Optional[dict] = None, **kwargs):
+        """
+        Text generation wrapper with per-model thinking support.
+        """
+        client = self.get_client()
+        request_kwargs = {
+            "model": model,
+            "prompt": prompt
+        }
+        if options is not None:
+            request_kwargs["options"] = options
+        request_kwargs.update(kwargs)
+
+        thinking = self._resolve_model_thinking(model)
+        if thinking is not None:
+            request_kwargs["think"] = thinking
+
+        try:
+            return client.generate(**request_kwargs)
+        except TypeError as error:
+            # Backward compatibility with ollama clients not supporting think=
+            error_message = error.args[0] if error.args else ""
+            if (
+                "think" in request_kwargs
+                and "unexpected keyword argument 'think'" in str(error_message)
+            ):
+                request_kwargs.pop("think", None)
+                return client.generate(**request_kwargs)
+            raise
     
     def get_available_models(self, show_formatted: bool = False) -> List[str]:
         """

--- a/oasis/ollama_manager.py
+++ b/oasis/ollama_manager.py
@@ -114,14 +114,22 @@ class OllamaManager:
         """
         return self._model_thinking_overrides.get(model)
 
-    def chat(self, model: str, messages: List[dict], options: Optional[dict] = None, **kwargs):
+    def _call_with_thinking(
+        self,
+        method_name: str,
+        model: str,
+        payload_key: str,
+        payload_value: Any,
+        options: Optional[dict] = None,
+        **kwargs: Any
+    ):
         """
-        Chat completion wrapper with per-model thinking support.
+        Execute an Ollama client call with optional per-model thinking behavior.
         """
         client = self.get_client()
         request_kwargs = {
             "model": model,
-            "messages": messages
+            payload_key: payload_value
         }
         if options is not None:
             request_kwargs["options"] = options
@@ -131,8 +139,9 @@ class OllamaManager:
         if thinking is not None:
             request_kwargs["think"] = thinking
 
+        method = getattr(client, method_name)
         try:
-            return client.chat(**request_kwargs)
+            return method(**request_kwargs)
         except TypeError as error:
             # Backward compatibility with ollama clients not supporting think=
             error_message = error.args[0] if error.args else ""
@@ -141,38 +150,34 @@ class OllamaManager:
                 and "unexpected keyword argument 'think'" in str(error_message)
             ):
                 request_kwargs.pop("think", None)
-                return client.chat(**request_kwargs)
+                return method(**request_kwargs)
             raise
+
+    def chat(self, model: str, messages: List[dict], options: Optional[dict] = None, **kwargs):
+        """
+        Chat completion wrapper with per-model thinking support.
+        """
+        return self._call_with_thinking(
+            method_name="chat",
+            model=model,
+            payload_key="messages",
+            payload_value=messages,
+            options=options,
+            **kwargs
+        )
 
     def generate(self, model: str, prompt: str, options: Optional[dict] = None, **kwargs):
         """
         Text generation wrapper with per-model thinking support.
         """
-        client = self.get_client()
-        request_kwargs = {
-            "model": model,
-            "prompt": prompt
-        }
-        if options is not None:
-            request_kwargs["options"] = options
-        request_kwargs.update(kwargs)
-
-        thinking = self._resolve_model_thinking(model)
-        if thinking is not None:
-            request_kwargs["think"] = thinking
-
-        try:
-            return client.generate(**request_kwargs)
-        except TypeError as error:
-            # Backward compatibility with ollama clients not supporting think=
-            error_message = error.args[0] if error.args else ""
-            if (
-                "think" in request_kwargs
-                and "unexpected keyword argument 'think'" in str(error_message)
-            ):
-                request_kwargs.pop("think", None)
-                return client.generate(**request_kwargs)
-            raise
+        return self._call_with_thinking(
+            method_name="generate",
+            model=model,
+            payload_key="prompt",
+            payload_value=prompt,
+            options=options,
+            **kwargs
+        )
     
     def get_available_models(self, show_formatted: bool = False) -> List[str]:
         """


### PR DESCRIPTION
## Summary by Sourcery

Add configurable per-model thinking support and route Oasis analysis and extraction calls through the Ollama manager while documenting new CLI flags and editor rules.

New Features:
- Introduce per-model thinking configuration in the Ollama manager for both chat and generate requests.
- Add CLI flags to enable or disable thinking separately for scan and deep analysis models.

Enhancements:
- Refactor Oasis analysis and embedding flows to use the Ollama manager wrappers instead of accessing the raw client directly.
- Add internal Cursor skills and rules files to encode Oasis implementation and release patterns.

Documentation:
- Update README with documentation for the new model thinking CLI options.