### PR TITLE
feat: add structured JSON analysis, canonical reports, SARIF export, and dashboard upgrades

### DIFF
--- a/.cursor/rules/git-history-conventions.mdc
+++ b/.cursor/rules/git-history-conventions.mdc
@@ -9,4 +9,6 @@ alwaysApply: true
 - Keep commit subjects short and scoped to user-visible intent (why), not low-level implementation detail.
 - For release-oriented changes, keep version, changelog, and docs aligned in the same working session.
 - When a CLI flag or behavior changes, update `README.md` in the same change to avoid drift.
+- When install or upgrade steps change, keep `README.md` aligned with the **pipx** workflow (`pipx uninstall oasis && pipx install -e .`).
+- When structured output or report schema changes, align `oasis/schemas/`, report templates, and contract tests (e.g., `tests/test_report_schema.py`) in the same change set.
 - Prefer incremental commits focused on one concern (e.g., caching, web UI bugfixes, model integration).

--- a/.cursor/rules/oasis-dashboard-js-patterns.mdc
+++ b/.cursor/rules/oasis-dashboard-js-patterns.mdc
@@ -6,8 +6,10 @@ alwaysApply: false
 
 # OASIS Dashboard JS Patterns
 
-- Keep dashboard code modular by concern (`api`, `filters`, `interactions`, `modal`, `views`, `utils`).
+- Keep dashboard code modular by concern (`bootstrap`, `api`, `filters`, `interactions`, `modal`, `views`, `utils`).
 - Extend the shared `DashboardApp` namespace instead of introducing parallel globals.
 - Centralize formatting and display helpers in utility modules to avoid duplicated logic.
 - When fixing UI bugs, update both interaction scripts and matching templates if the issue spans behavior and markup.
 - Prefer compatibility-safe fixes that preserve existing dashboard data contracts (`report` fields and optional defaults).
+- Vulnerability stats come from **`stats` on `format: "json"`** rows (`total_findings`, `high_risk`, etc.). Reload must pass **`force=1`** to both `/api/stats` and `/api/reports` when refreshing the filesystem-backed index.
+- Modal preview: **`json`** uses `/api/report-json/...`; **`md`** uses `/api/report-content/...` only for legacy reports (no sibling `json/<stem>.json`).

--- a/.cursor/rules/oasis-dev-install-pipx.mdc
+++ b/.cursor/rules/oasis-dev-install-pipx.mdc
@@ -1,0 +1,30 @@
+---
+description: Local OASIS CLI install and refresh via pipx editable mode
+alwaysApply: true
+---
+
+# OASIS development install (pipx)
+
+- Install or refresh the `oasis` CLI from the repository root using **pipx** with an editable install:
+
+```bash
+pipx uninstall oasis && pipx install -e .
+```
+
+- Use this flow after dependency or entrypoint changes so the isolated venv matches the working tree.
+- Do not assume a global `pip install`; the project standard for local tooling is **pipx**.
+---
+description: Local OASIS CLI install via pipx (editable dev workflow)
+alwaysApply: true
+---
+
+# OASIS development install (pipx)
+
+- Install or refresh the `oasis` CLI from the repository root using **pipx** with an editable install:
+
+```bash
+pipx uninstall oasis && pipx install -e .
+```
+
+- Use this flow after dependency or entrypoint changes so the isolated venv matches the working tree.
+- Do not assume a global `pip install`; the project standard for local tooling is **pipx**.

--- a/.cursor/rules/oasis-dev-install-pipx.mdc
+++ b/.cursor/rules/oasis-dev-install-pipx.mdc
@@ -1,30 +1,25 @@
 ---
-description: Local OASIS CLI install and refresh via pipx editable mode
+description: Local OASIS install and tests via pipx editable workflow
 alwaysApply: true
 ---
 
 # OASIS development install (pipx)
 
-- Install or refresh the `oasis` CLI from the repository root using **pipx** with an editable install:
+- Install or refresh the `oasis` CLI using **pipx** with an editable install:
 
 ```bash
 pipx uninstall oasis && pipx install -e .
 ```
 
+- If `pipx uninstall oasis` is interpreted as a local path (because an `oasis/` directory exists), run the command from outside the repository root.
 - Use this flow after dependency or entrypoint changes so the isolated venv matches the working tree.
 - Do not assume a global `pip install`; the project standard for local tooling is **pipx**.
----
-description: Local OASIS CLI install via pipx (editable dev workflow)
-alwaysApply: true
----
 
-# OASIS development install (pipx)
+# OASIS test execution (pipx)
 
-- Install or refresh the `oasis` CLI from the repository root using **pipx** with an editable install:
+- Run Python tests through the pipx environment, not the system Python.
+- Recommended command pattern:
 
 ```bash
-pipx uninstall oasis && pipx install -e .
+PYTHONPATH="$(pwd)" pipx run --spec . python -m unittest tests.<module_or_class>
 ```
-
-- Use this flow after dependency or entrypoint changes so the isolated venv matches the working tree.
-- Do not assume a global `pip install`; the project standard for local tooling is **pipx**.

--- a/.cursor/rules/oasis-python-architecture.mdc
+++ b/.cursor/rules/oasis-python-architecture.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # OASIS Python Architecture
 
-- Keep responsibilities split by module: orchestration in `oasis/oasis.py`, analysis in `oasis/analyze.py`, model lifecycle in `oasis/ollama_manager.py`, and shared utilities in dedicated helper modules.
+- Keep responsibilities split by module: orchestration in `oasis/oasis.py`, analysis in `oasis/analyze.py`, structured schemas in `oasis/schemas/`, canonical JSON + Jinja report rendering in `oasis/report.py`, dashboard indexing in `oasis/web.py`, model lifecycle in `oasis/ollama_manager.py`, and shared utilities in dedicated helper modules.
 - Favor small manager/service classes over monolithic procedural flows when adding features.
 - Preserve CLI backward compatibility when possible (short and long flags); if a rename is required, mirror it in docs.
 - Route logs through centralized project logging helpers; avoid ad-hoc print statements in production paths.

--- a/.cursor/skills/oasis-implementation-patterns/SKILL.md
+++ b/.cursor/skills/oasis-implementation-patterns/SKILL.md
@@ -14,12 +14,16 @@ Apply the code organization and delivery style repeatedly used in OASIS commits.
 1. Classify the change as `feat`, `fix`, or `refactor`.
 2. Identify the bounded module(s) to touch instead of editing a single large file:
    - `oasis/oasis.py`: CLI and orchestration
-   - `oasis/analyze.py`: analysis logic
+   - `oasis/analyze.py`: analysis logic (Ollama structured outputs for scan / deep / adaptive)
+   - `oasis/schemas/`: Pydantic models for LLM JSON and canonical vulnerability reports
+   - `oasis/report.py`: JSON-first vulnerability reports; Jinja under `oasis/templates/reports/`
+   - `oasis/web.py`: dashboard indexing (`json/` stats), APIs (`/api/report-json`, legacy MD preview rules)
    - `oasis/ollama_manager.py`: model and Ollama interactions
-   - `oasis/static/js/dashboard/*`: web dashboard behavior
+   - `oasis/static/js/dashboard/*`: web dashboard behavior (JSON modal preview, `force=1` on reload)
 3. Keep interfaces compatible unless migration is explicit.
 4. Update docs (`README.md`) when user-facing flags or behavior change.
 5. Prefer defensive handling around cache/model/network boundaries.
+6. For reporting changes, treat canonical JSON schema as the source of truth and keep Jinja templates synchronized.
 
 ## Design Guardrails
 
@@ -32,4 +36,5 @@ Apply the code organization and delivery style repeatedly used in OASIS commits.
 
 - No obvious module boundary violation.
 - Any CLI option change is documented.
+- Structured output/report changes stay aligned across `oasis/schemas/`, `oasis/report.py`, `oasis/templates/reports/`, and `tests/test_report_schema.py`.
 - Change intent can be summarized with a conventional commit subject.

--- a/.cursor/skills/oasis-release-guardrails/SKILL.md
+++ b/.cursor/skills/oasis-release-guardrails/SKILL.md
@@ -16,6 +16,7 @@ Keep release changes coherent across code, docs, and metadata like historical `r
 - [ ] Update `CHANGELOG.md` for user-visible behavior changes.
 - [ ] Verify `README.md` reflects CLI options and workflow changes.
 - [ ] Ensure dashboard/web changes include matching template/assets updates when required.
+- [ ] For structured output/report changes, keep schema models, templates, and report contract tests in sync.
 
 ## Commit Guidance
 
@@ -30,3 +31,4 @@ Before finalizing:
 1. Re-read changed docs and confirm they match actual CLI/runtime behavior.
 2. Confirm no stale option name remains after renames.
 3. Ensure change grouping is logical (avoid mixing unrelated concerns).
+4. Run and review the report contract test path (at least `tests/test_report_schema.py`) before release tagging.

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.coverage
 
 # Virtual Environment
 venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 🚀 [0.5.0] - 2026-04-17
 
 ### ✨ Added
+- 📍 Added source line metadata: chunk `start_line` / `end_line`, optional per-finding `snippet_start_line` / `snippet_end_line` when the vulnerable snippet is found in the chunk text, SARIF `region` (snippet span preferred over chunk span), and report hints (analysis schema version **3**)
 - 🤔 Added Ollama thinking toggles for scan vs deep models (`--model-thinking` / `-mt`, `--small-model-thinking` / `-smt`)
 - 📋 Added structured vulnerability analysis (Pydantic) with JSON normalization and repair for flaky model output
 - 📄 Added canonical JSON reports (`report.json`) via `--output-format` (with `all` and comma-separated lists)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 🚀 [0.5.0] - 2026-04-17
+
+### ✨ Added
+- 🤔 Added Ollama thinking toggles for scan vs deep models (`--model-thinking` / `-mt`, `--small-model-thinking` / `-smt`)
+- 📋 Added structured vulnerability analysis (Pydantic) with JSON normalization and repair for flaky model output
+- 📄 Added canonical JSON reports (`report.json`) via `--output-format` (with `all` and comma-separated lists)
+- 🛡️ Added SARIF 2.1.0 export (`sarif/*.sarif`) and dashboard downloads for SARIF
+- 🧭 Added `.cursor/` rules and agent skills for implementation, releases, and git conventions
+
+### 🐛 Fixed
+- 🔧 Fixed missing `analyze_type` in the embedding analyzer
+- 📝 Fixed vulnerability cards: title/summary shown before the code snippet
+- 🔗 Fixed broken download links in the report modal
+- 🖥️ Fixed small dashboard issues (types display, parallel refresh, debug logging)
+
+### ⚡ Changed
+- 💾 Changed cache layout: per-project folders under `.oasis_cache`, schema-aware cleanup for structured outputs
+- 🗂️ Changed export writes into `oasis.export` to slim down `report.py`
+- 📚 Changed README: `--input` docs, structured-output notes, report folder layout
+- 🎨 Changed logo asset
+
 ## 🚀 [0.4.0] - 2025-03-21
 
 ### ✨ Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - 🔄 **Interactive Model Selection**: Guided selection of scan and analysis models with parameter-based filtering
 - 💾 **Dual-Layer Caching**: Efficient caching for both embeddings and analysis results to dramatically speed up repeated scans
 - 🔧 **Scan Result Caching**: Store and reuse vulnerability analysis results with model-specific caching
-- 📊 **Rich Reporting**: Detailed reports in multiple formats (Markdown, PDF, HTML)
+- 📊 **Rich Reporting**: Canonical JSON reports plus derived HTML, PDF, and Markdown exports
 - 🔄 **Parallel Processing**: Optimized performance through parallel vulnerability analysis
 - 📝 **Executive Summaries**: Clear overview of all detected vulnerabilities
 - 🎯 **Customizable Scans**: Support for specific vulnerability types and file extensions
@@ -362,19 +362,31 @@ For the best results with OASIS:
 
 ## 📁 Output Structure
 
+Vulnerability runs are stored under a timestamped directory. For each model, per-format folders include a **canonical JSON** report (`json/*.json`) used by the web dashboard for statistics and previews. HTML and PDF are rendered from that JSON via Jinja2; Markdown is an additional human-readable export.
+
 ```
 security_reports/
-├── [model_name]/
-│   ├── markdown/
-│   │   ├── vulnerability_type.md
-│   │   └── executive_summary.md
-│   ├── pdf/
-│   │   ├── vulnerability_type.pdf
-│   │   └── executive_summary.pdf
-│   └── html/
-│       ├── vulnerability_type.html
-│       └── executive_summary.html
+└── [input_basename]_YYYYMMDD_HHMMSS/
+    └── [sanitized_model_name]/
+        ├── json/
+        │   └── vulnerability_type.json
+        ├── md/
+        │   └── vulnerability_type.md
+        ├── html/
+        │   └── vulnerability_type.html
+        └── pdf/
+            └── vulnerability_type.pdf
 ```
+
+### Ollama structured outputs
+
+Deep and scan analysis calls use Ollama **structured outputs** (`format` with a JSON schema). Use a recent Ollama server; model quality still varies by GGUF. If structured validation fails, the analyzer falls back to safe defaults or regex (function extraction only).
+
+### Web dashboard and Reload
+
+- Statistics and risk summaries are read from **`json/*.json`**.
+- **Reload** refreshes both `/api/stats?force=1` and `/api/reports?force=1` so listings stay in sync with the filesystem.
+- Markdown preview (`/api/report-content/...`) remains available **only when no `json/<same-stem>.json` exists** for that report (legacy scans). Otherwise use JSON preview (`/api/report-json/...`).
 
 ## 💾 Cache Management
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ Vulnerability runs are stored under a timestamped directory. For each model, per
 ```
 security_reports/
 └── [input_basename]_YYYYMMDD_HHMMSS/
+    ├── logs/
+    │   └── oasis_errors_[run_id].log
     └── [sanitized_model_name]/
         ├── json/
         │   └── vulnerability_type.json
@@ -382,11 +384,41 @@ security_reports/
 
 Deep and scan analysis calls use Ollama **structured outputs** (`format` with a JSON schema). Use a recent Ollama server; model quality still varies by GGUF. If structured validation fails, the analyzer falls back to safe defaults or regex (function extraction only).
 
+### Structured output hardening
+
+Use this priority order to reduce invalid JSON responses (`Field required`, `json_invalid`, `EOF while parsing a string`):
+
+1. **Model selection first**
+   - Choose a scan model that is stable with strict JSON outputs.
+   - Keep a deep model only if it stays stable across repeated runs on the same corpus.
+   - Compare candidates with the same target files and track invalid JSON rate + average chunk latency.
+2. **Ollama generation settings**
+   - Keep conservative generation settings for structured scan/deep calls.
+   - Keep thinking disabled for strict JSON runs unless a model explicitly requires it.
+   - Ensure chunk size and model context window are compatible to avoid truncated outputs.
+3. **Targeted retry policy**
+   - Retry only known structured failures: missing required `verdict` (scan) and invalid/truncated JSON (`json_invalid`, `EOF while parsing`) for deep responses.
+   - Keep retries bounded (scan: up to 2 retries, deep: up to 1 retry) and append a strict JSON correction reminder on retries.
+   - Keep final fallback behavior deterministic when retries fail.
+4. **Operational safeguards**
+   - Track invalid JSON ratio per run and alert when it exceeds your acceptance threshold.
+   - Review `security_reports/<run_id>/logs/oasis_errors_<run_id>.log` after each scan to identify the failing model/phase/chunk quickly.
+
+Each structured-output error log line includes context fields such as run identifier, model, phase, vulnerability (if available), file path, chunk index, exception type, and a truncated raw preview.
+Retry-aware logs also include `retry_attempt` and `retry_max` so you can distinguish first failure from final fallback.
+
+Example hardened command:
+
+```bash
+oasis -i ./critical-service -sm qwen2.5-coder:7b -m bugtraceai-apex-q4 --adaptive -t 0.6 -smt no -mt no
+```
+
 ### Web dashboard and Reload
 
 - Statistics and risk summaries are read from **`json/*.json`**.
 - **Reload** refreshes both `/api/stats?force=1` and `/api/reports?force=1` so listings stay in sync with the filesystem.
-- Markdown preview (`/api/report-content/...`) remains available **only when no `json/<same-stem>.json` exists** for that report (legacy scans). Otherwise use JSON preview (`/api/report-json/...`).
+- Canonical JSON reports are previewed in the Web UI by rendering HTML from the JSON via the Jinja template, so the modal matches the HTML/PDF structure as closely as possible.
+- Markdown preview (`/api/report-content/...`) remains the fallback for legacy reports that do not have a sibling `json/<same-stem>.json`, or when canonical JSON HTML preview cannot be generated.
 
 ## 💾 Cache Management
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ oasis -i [path_to_analyze] -sm gemma3:4b -m llama3:latest,codellama:lates -t 0.7
 
 ### Input/Output Options
 - `--input` `-i`: Path to file, directory, or .txt file containing newline-separated paths to analyze
-- `--output-format` `-of`: Output format [pdf, html, md] (default: all)
+- `--output-format` `-of`: Comma-separated formats or `all` for json, sarif, pdf, html, md (default: all)
 - `--extensions` `-x`: Custom file extensions to analyze (e.g., "py,js,java")
 
 ### Analysis Configuration
@@ -362,7 +362,7 @@ For the best results with OASIS:
 
 ## 📁 Output Structure
 
-Vulnerability runs are stored under a timestamped directory. For each model, per-format folders include a **canonical JSON** report (`json/*.json`) used by the web dashboard for statistics and previews. HTML and PDF are rendered from that JSON via Jinja2; Markdown is an additional human-readable export.
+Vulnerability runs are stored under a timestamped directory. For each model, per-format folders include a **canonical JSON** report (`json/*.json`) used by the web dashboard for statistics and previews. **SARIF 2.1.0** (`sarif/*.sarif`) is generated from the same document for toolchains (DefectDojo, SonarQube, IDE SARIF viewers). HTML and PDF are rendered from that JSON via Jinja2; Markdown is an additional human-readable export.
 
 ```
 security_reports/
@@ -372,6 +372,8 @@ security_reports/
     └── [sanitized_model_name]/
         ├── json/
         │   └── vulnerability_type.json
+        ├── sarif/
+        │   └── vulnerability_type.sarif
         ├── md/
         │   └── vulnerability_type.md
         ├── html/

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ For the best results with OASIS:
 
 ## 📁 Output Structure
 
-Vulnerability runs are stored under a timestamped directory. For each model, per-format folders include a **canonical JSON** report (`json/*.json`) used by the web dashboard for statistics and previews. **SARIF 2.1.0** (`sarif/*.sarif`) is generated from the same document for toolchains (DefectDojo, SonarQube, IDE SARIF viewers). HTML and PDF are rendered from that JSON via Jinja2; Markdown is an additional human-readable export.
+Vulnerability runs are stored under a timestamped directory. For each model, per-format folders include a **canonical JSON** report (`json/*.json`) used by the web dashboard for statistics and previews. Chunk objects may include **`start_line` / `end_line`** (1-based inclusive bounds for the analyzed source segment, computed at split time, not inferred by the model). Each finding may include **`snippet_start_line` / `snippet_end_line`** when the tool can match `vulnerable_code` inside that chunk (otherwise SARIF falls back to the chunk span). **SARIF 2.1.0** (`sarif/*.sarif`) is generated from the same document for toolchains (DefectDojo, SonarQube, IDE SARIF viewers) and maps those spans to `region.startLine` / `region.endLine` when available. HTML and PDF are rendered from that JSON via Jinja2; Markdown is an additional human-readable export.
 
 ```
 security_reports/

--- a/oasis/__init__.py
+++ b/oasis/__init__.py
@@ -2,6 +2,10 @@
 OASIS - Ollama Automated Security Intelligence Scanner
 """
 
-from .oasis import main
-
 __version__ = "0.5.0" 
+
+
+def main():
+    from .oasis import main as _main
+
+    return _main()

--- a/oasis/analyze.py
+++ b/oasis/analyze.py
@@ -1,9 +1,12 @@
 import argparse
-from typing import List, Dict, Tuple, Any, Union
+import json
+import re
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+from pydantic import BaseModel, ValidationError
 from tqdm import tqdm
 from multiprocessing import Pool, cpu_count
-import re
 
 # Import from configuration
 from .config import CHUNK_ANALYZE_TIMEOUT, MODEL_EMOJIS, VULNERABILITY_PROMPT_EXTENSION, EMBEDDING_THRESHOLDS, MAX_CHUNK_SIZE, DEFAULT_ARGS
@@ -15,11 +18,28 @@ from .report import Report
 from .embedding import EmbeddingManager, build_vulnerability_embedding_prompt
 from .cache import CacheManager
 from .enums import AnalysisMode, AnalysisType
+from .schemas.analysis import (
+    ANALYSIS_SCHEMA_VERSION,
+    ChunkDeepAnalysis,
+    MediumRiskAnalysis,
+    ScanVerdict,
+    chunk_analysis_to_markdown,
+)
+
+STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN = 500
 
 # Define analysis modes and types
+# Handler receives either ValidationError (schema mismatch) or runtime/transport exceptions.
+StructuredOutputFailureHandler = Callable[
+    [Type[BaseModel], str, Exception, str],
+    Optional[str],
+]
+
+
 class SecurityAnalyzer:
     def __init__(self, args, llm_model: str, embedding_manager: EmbeddingManager, ollama_manager: OllamaManager,
-                 scan_model: str = None):
+                 scan_model: str = None,
+                 structured_output_failure_handler: Optional[StructuredOutputFailureHandler] = None):
         """
         Initialize the security analyzer with support for tiered model analysis
 
@@ -71,11 +91,169 @@ class SecurityAnalyzer:
         )
         
         self.analysis_pipeline = AdaptiveAnalysisPipeline(self)
+        self.structured_output_failure_handler = structured_output_failure_handler
+        self.run_id = getattr(args, "run_id", None)
 
         # Clear scan cache if requested
         if hasattr(self, 'clear_cache_scan') and self.clear_cache_scan:
             analysis_type = AnalysisType.ADAPTIVE if self.analyze_by_function else AnalysisType.STANDARD
             self.cache_manager.clear_scan_cache(analysis_type)
+
+    def _default_structured_output_failure(
+        self,
+        response_model: Type[BaseModel],
+        error: Exception,
+    ) -> str:
+        if issubclass(response_model, ScanVerdict):
+            return "ERROR"
+        if issubclass(response_model, MediumRiskAnalysis):
+            return MediumRiskAnalysis(
+                risk_score=50,
+                analysis=f"Structured output failure: {error}",
+                validation_error=True,
+            ).model_dump_json()
+        return ChunkDeepAnalysis(
+            findings=[],
+            notes=f"Structured output failure: {error}",
+            validation_error=True,
+        ).model_dump_json()
+
+    def _resolve_structured_output_failure(
+        self,
+        response_model: Type[BaseModel],
+        raw: str,
+        error: Exception,
+        model_display: str,
+    ) -> str:
+        """Resolve structured-output failure from either validation or transport/runtime errors."""
+        handler = self.structured_output_failure_handler
+        if handler is not None:
+            handled = handler(response_model, raw, error, model_display)
+            if handled is not None:
+                return handled
+        return self._default_structured_output_failure(response_model, error)
+
+    def _parse_structured_output_response(
+        self,
+        raw: str,
+        response_model: Type[BaseModel],
+        model_display: str,
+        file_path: Optional[str] = None,
+        vuln_name: Optional[str] = None,
+        retry_attempt: Optional[int] = None,
+        retry_max: Optional[int] = None,
+        raise_validation_error: bool = False,
+    ) -> str:
+        """
+        Parse and normalize structured LLM output for one response model.
+
+        Contract:
+        - Scan models return a plain verdict string.
+        - Non-scan models return JSON serialized by the target Pydantic schema.
+        - Validation failures are converted through the structured fallback strategy.
+        """
+        try:
+            parsed = response_model.model_validate_json(raw)
+        except ValidationError as exc:
+            phase_name = "scan" if issubclass(response_model, ScanVerdict) else "deep"
+            self._log_structured_output_error(
+                phase=phase_name,
+                response_model=response_model,
+                model_display=model_display,
+                raw=raw,
+                error=exc,
+                file_path=file_path,
+                vuln_name=vuln_name,
+                retry_attempt=retry_attempt,
+                retry_max=retry_max,
+            )
+            logger.warning(f"Structured output validation failed ({model_display}): {exc}")
+            raw_preview = (raw or "")[:STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN]
+            if len(raw or "") > STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN:
+                raw_preview += "... [truncated]"
+            logger.debug(f"Structured output raw preview ({model_display}): {raw_preview}")
+            if raise_validation_error:
+                raise
+            return self._resolve_structured_output_failure(
+                response_model=response_model,
+                raw=raw,
+                error=exc,
+                model_display=model_display,
+            )
+
+        if issubclass(response_model, ScanVerdict):
+            return parsed.verdict
+        return parsed.model_dump_json()
+
+    def _log_structured_output_error(
+        self,
+        *,
+        phase: str,
+        response_model: Type[BaseModel],
+        model_display: str,
+        raw: str,
+        error: Exception,
+        file_path: Optional[str] = None,
+        vuln_name: Optional[str] = None,
+        chunk_index: Optional[int] = None,
+        retry_attempt: Optional[int] = None,
+        retry_max: Optional[int] = None,
+    ) -> None:
+        """
+        Emit structured context for LLM JSON failures to error log files.
+        """
+        raw_text = raw or ""
+        raw_preview = raw_text[:STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN]
+        raw_truncated = len(raw_text) > STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN
+
+        payload = {
+            "event": "structured_output_error",
+            "run_id": self.run_id,
+            "phase": phase,
+            "model": model_display,
+            "response_model": response_model.__name__,
+            "vulnerability": vuln_name,
+            "file_path": file_path,
+            "chunk_index": chunk_index,
+            "error_type": error.__class__.__name__,
+            "message": str(error),
+            "retry_attempt": retry_attempt,
+            "retry_max": retry_max,
+            "raw_preview": raw_preview,
+            "raw_truncated": raw_truncated,
+        }
+        logger.error("Structured output error context: %s", json.dumps(payload, ensure_ascii=True))
+
+    def _is_retryable_structured_error(
+        self,
+        response_model: Type[BaseModel],
+        error: Exception,
+    ) -> bool:
+        """Return True when the validation failure matches known transient JSON issues."""
+        message = str(error)
+        if issubclass(response_model, ScanVerdict):
+            return "Field required" in message and "verdict" in message
+        return "json_invalid" in message or "EOF while parsing" in message
+
+    def _get_structured_retry_limit(self, response_model: Type[BaseModel]) -> int:
+        """Bound retry count per structured model type."""
+        return 2 if issubclass(response_model, ScanVerdict) else 1
+
+    def _build_structured_retry_suffix(self, response_model: Type[BaseModel]) -> str:
+        """Build minimal correction reminder appended to the prompt on retry."""
+        if issubclass(response_model, ScanVerdict):
+            return (
+                "\n\nCORRECTION: Return EXACTLY one JSON object with one key only.\n"
+                'Valid outputs: {"verdict":"SUSPICIOUS"} | {"verdict":"CLEAN"} | {"verdict":"ERROR"}.\n'
+                "Do NOT output schema keys (description/properties/required/title/type).\n"
+                "Do NOT use markdown code fences.\n"
+            )
+        return (
+            "\n\nCORRECTION: Return valid JSON only (single object matching the required schema).\n"
+            "Do NOT use markdown code fences.\n"
+            "Return compact JSON with no explanations, no repeated filler tokens, and no trailing commentary.\n"
+            "Ensure every quote/bracket is closed and output ends with the final '}' of the JSON object.\n"
+        )
         
     def _get_vulnerability_details(self, vulnerability: Union[str, Dict]) -> Tuple[str, str, list, str, str]:
         """
@@ -120,11 +298,9 @@ class SecurityAnalyzer:
             f"- Mitigation: {vuln_mitigation}"
         )
         
-        # Get common format requirements
-        common_prompt = _get_common_prompt(vuln_name)
-        
-        # Build the complete prompt with clear sections and strict instructions
-        return f"""You are a cybersecurityy expert specialized in {vuln_name} vulnerabilities ONLY. 
+        common_prompt = _get_structured_deep_instructions(vuln_name)
+
+        return f"""You are a cybersecurity expert specialized in {vuln_name} vulnerabilities ONLY.
 
 CRITICAL INSTRUCTION: You must ONLY analyze the code for {vuln_name} vulnerabilities.
 DO NOT mention, describe, or analyze ANY other type of vulnerability.
@@ -146,55 +322,97 @@ Analyze this code segment ({i + 1}/{total_chunks}) for {vuln_name} vulnerabiliti
 {VULNERABILITY_PROMPT_EXTENSION}
 """
 
-    def _analyze_code_chunk(self, prompt: str, file_path: str = None, chunk_text: str = None, 
-                           vuln_name: str = None, mode: AnalysisMode = AnalysisMode.DEEP,
-                           analysis_type: AnalysisType = AnalysisType.STANDARD) -> str:
+    def _analyze_code_chunk(
+        self,
+        prompt: str,
+        file_path: str = None,
+        chunk_text: str = None,
+        vuln_name: str = None,
+        mode: AnalysisMode = AnalysisMode.DEEP,
+        analysis_type: AnalysisType = AnalysisType.STANDARD,
+        ollama_json_format: Optional[dict] = None,
+        response_model: Optional[Type[BaseModel]] = None,
+    ) -> str:
         """
         Analyze a single code chunk with the appropriate LLM based on mode.
-        
-        Args:
-            prompt: Prompt to analyze
-            file_path: Path to the file being analyzed (for caching)
-            chunk_text: The code chunk being analyzed (for caching)
-            vuln_name: Vulnerability name (for better organization)
-            mode: Analysis mode (scan or deep)
-            analysis_type: Analysis type (standard or adaptive)
-        """
-        # Select the appropriate model
-        model = self.scan_model if mode == AnalysisMode.SCAN else self.llm_model
 
-        # Display model name with emoji
+        When ollama_json_format and response_model are set, uses Ollama structured outputs
+        and returns: scan verdict as plain string, or model_dump_json() for structured models.
+        """
+        model = self.scan_model if mode == AnalysisMode.SCAN else self.llm_model
         model_display = self.ollama_manager.get_model_display_name(model)
 
-        # If caching info is provided, check appropriate cache first
         if self.cache_manager.has_caching_info(file_path, chunk_text, vuln_name, analysis_type):
-            if cached_result := self.cache_manager.get_cached_analysis(file_path, chunk_text, vuln_name, prompt, mode, analysis_type):
-                logger.debug(f"Using cached {mode.value} {analysis_type.value} analysis for chunk in {file_path} with {model_display}")
+            if cached_result := self.cache_manager.get_cached_analysis(
+                file_path, chunk_text, vuln_name, prompt, mode, analysis_type
+            ):
+                logger.debug(
+                    f"Using cached {mode.value} {analysis_type.value} analysis for chunk in {file_path} with {model_display}"
+                )
                 return cached_result
 
         try:
-            # Add timeout to prevent infinite waiting
-            timeout = CHUNK_ANALYZE_TIMEOUT  # Timeout in seconds (2 minutes)
+            timeout = CHUNK_ANALYZE_TIMEOUT
+            opts: dict = {"timeout": timeout * 1000}
+            retry_limit = self._get_structured_retry_limit(response_model) if response_model is not None else 0
+            effective_prompt = prompt
 
             logger.debug(f"Analyzing chunk with {model_display}")
 
-            # Make the API call with timeout
-            response = self.ollama_manager.chat(
-                model=model,
-                messages=[{'role': 'user', 'content': prompt}],
-                options={"timeout": timeout * 1000}  # Convert to milliseconds if API supports it
-            )
+            for attempt in range(retry_limit + 1):
+                chat_kwargs: dict = {
+                    "model": model,
+                    "messages": [{"role": "user", "content": effective_prompt}],
+                    "options": opts,
+                }
+                if ollama_json_format is not None:
+                    chat_kwargs["format"] = ollama_json_format
 
-            result = response['message']['content']
+                response = self.ollama_manager.chat(**chat_kwargs)
+                raw = response["message"]["content"]
 
-            # Cache the result if caching info is provided
+                if response_model is None:
+                    result = raw
+                    break
+
+                try:
+                    result = self._parse_structured_output_response(
+                        raw=raw,
+                        response_model=response_model,
+                        model_display=model_display,
+                        file_path=file_path,
+                        vuln_name=vuln_name,
+                        retry_attempt=attempt + 1,
+                        retry_max=retry_limit,
+                        raise_validation_error=True,
+                    )
+                    break
+                except ValidationError as exc:
+                    if attempt < retry_limit and self._is_retryable_structured_error(response_model, exc):
+                        effective_prompt = effective_prompt + self._build_structured_retry_suffix(response_model)
+                        continue
+                    result = self._resolve_structured_output_failure(
+                        response_model=response_model,
+                        raw=raw,
+                        error=exc,
+                        model_display=model_display,
+                    )
+                    break
+
             if self.cache_manager.has_caching_info(file_path, chunk_text, vuln_name, analysis_type):
                 self.cache_manager.store_analysis(file_path, chunk_text, vuln_name, prompt, result, mode, analysis_type)
 
             return result
         except Exception as e:
             logger.exception(f"Error during chunk analysis with {model_display}: {str(e)}")
-            return f"Error during chunk analysis: {str(e)}"
+            if response_model is not None:
+                return self._resolve_structured_output_failure(
+                    response_model=response_model,
+                    raw="",
+                    error=e,
+                    model_display=model_display,
+                )
+            return f"Error during chunk analysis: {e}"
 
     def _build_scan_prompt(self, vuln_name: str, vuln_desc: str, chunk_text: str) -> str:
         """
@@ -213,18 +431,21 @@ Description of vulnerability: {vuln_desc}
 
 IMPORTANT INSTRUCTIONS:
 1. Analyze the code below for ONLY {vuln_name} vulnerabilities
-2. DO NOT provide any explanations, details, or reasoning
-3. Respond with EXACTLY ONE WORD from these two options:
-   - "SUSPICIOUS" if there might be ANY {vuln_name} vulnerabilities
-   - "CLEAN" if you're confident there are NO {vuln_name} vulnerabilities
-
-YOUR RESPONSE MUST BE ONLY ONE OF THESE TWO WORDS: "SUSPICIOUS" or "CLEAN"
+2. Return EXACTLY one JSON object and nothing else.
+3. The object must contain only one key: "verdict".
+4. Allowed outputs are strictly:
+   {{"verdict":"SUSPICIOUS"}}
+   {{"verdict":"CLEAN"}}
+   {{"verdict":"ERROR"}}
+5. Do NOT include JSON Schema keys such as "description", "properties", "required", "title", or "type".
+6. Do NOT use markdown code fences.
+7. If your output is not valid JSON with exactly the key "verdict", regenerate before final answer.
+8. Use verdict "SUSPICIOUS" if there might be ANY {vuln_name} vulnerabilities, otherwise "CLEAN".
 
 Code to analyze:
 ```
 {chunk_text}
 ```
-YOUR FINAL ANSWER (MUST BE EXACTLY "SUSPICIOUS" OR "CLEAN"):
 """
 
     def search_vulnerabilities(self, vulnerability: Union[str, Dict], threshold: float = DEFAULT_ARGS['THRESHOLD']) -> List[Tuple[str, float]]:
@@ -442,14 +663,36 @@ YOUR FINAL ANSWER (MUST BE EXACTLY "SUSPICIOUS" OR "CLEAN"):
                 # Use a simplified prompt for the scanning phase
                 scan_prompt = self._build_scan_prompt(vuln_name, vuln_desc, chunk)
                 scan_result = self._analyze_code_chunk(
-                    scan_prompt, file_path, chunk, vuln_name, 
-                    mode=AnalysisMode.SCAN, 
-                    analysis_type=AnalysisType.STANDARD
+                    scan_prompt,
+                    file_path,
+                    chunk,
+                    vuln_name,
+                    mode=AnalysisMode.SCAN,
+                    analysis_type=AnalysisType.STANDARD,
+                    ollama_json_format=ScanVerdict.model_json_schema(),
+                    response_model=ScanVerdict,
                 )
-                
-                # Check if chunk is flagged as suspicious
-                if scan_result.strip() == "SUSPICIOUS":
+
+                scan_verdict = str(scan_result).strip().upper() if scan_result is not None else ""
+                if not scan_verdict:
+                    logger.warning(
+                        f"Empty structured scan verdict for chunk {i + 1} in {file_path}; treating as ERROR"
+                    )
+                    scan_verdict = "ERROR"
+                if scan_verdict == "SUSPICIOUS":
                     suspicious_chunks.append((i, chunk))
+                elif scan_verdict == "ERROR":
+                    logger.warning(
+                        f"Structured scan verdict validation failed for chunk {i + 1} in {file_path}; continuing"
+                    )
+                elif scan_verdict == "CLEAN":
+                    logger.debug(
+                        f"Structured scan verdict CLEAN for chunk {i + 1} in {file_path}"
+                    )
+                else:
+                    logger.warning(
+                        f"Unexpected structured scan verdict '{scan_verdict}' for chunk {i + 1} in {file_path}; treating as CLEAN"
+                    )
                     
                 chunk_pbar.update(1)
         
@@ -587,25 +830,45 @@ YOUR FINAL ANSWER (MUST BE EXACTLY "SUSPICIOUS" OR "CLEAN"):
 
                 # Analyze with the deep model
                 analysis_result = self._analyze_code_chunk(
-                    prompt, file_path, chunk, vuln_name, 
+                    prompt,
+                    file_path,
+                    chunk,
+                    vuln_name,
                     mode=AnalysisMode.DEEP,
-                    analysis_type=AnalysisType.STANDARD
+                    analysis_type=AnalysisType.STANDARD,
+                    ollama_json_format=ChunkDeepAnalysis.model_json_schema(),
+                    response_model=ChunkDeepAnalysis,
                 )
-                analyses.append(analysis_result)
+                try:
+                    analyses.append(ChunkDeepAnalysis.model_validate_json(analysis_result))
+                except ValidationError as exc:
+                    self._log_structured_output_error(
+                        phase="deep",
+                        response_model=ChunkDeepAnalysis,
+                        model_display=self.ollama_manager.get_model_display_name(self.llm_model),
+                        raw=analysis_result,
+                        error=exc,
+                        file_path=file_path,
+                        vuln_name=vuln_name,
+                        chunk_index=chunk_idx,
+                    )
+                    analyses.append(
+                        ChunkDeepAnalysis(findings=[], notes=f"Invalid chunk JSON: {analysis_result[:500]}")
+                    )
                 chunk_pbar.update(1)
 
-        # Skip files with no analyses
         if not analyses:
             return None
 
-        # Combine all analyses for this file
-        combined_analysis = "\n\n<div class=\"page-break\"></div>\n\n".join(analyses)
+        combined_analysis = "\n\n<div class=\"page-break\"></div>\n\n".join(
+            chunk_analysis_to_markdown(c, idx) for idx, c in enumerate(analyses)
+        )
 
-        # Create detailed result for this file
         return {
             'file_path': file_path,
             'similarity_score': similarity_score,
             'analysis': combined_analysis,
+            'structured_chunks': [c.model_dump() for c in analyses],
             'vulnerability': {
                 'name': vuln_name,
                 'description': vuln_desc,
@@ -1155,6 +1418,33 @@ class AdaptiveAnalysisPipeline:
         self.scan_model = analyzer.scan_model
         self.cache_manager = analyzer.cache_manager
         self.code_base = analyzer.code_base
+
+    @staticmethod
+    def _serialize_adaptive_envelope(markdown: str, structured_chunks: List[Dict[str, Any]]) -> str:
+        payload = {
+            "analysis": markdown,
+            "structured_chunks": structured_chunks,
+            "schema_version": ANALYSIS_SCHEMA_VERSION,
+        }
+        return json.dumps(payload)
+
+    @staticmethod
+    def _decode_adaptive_envelope(payload: Any) -> Tuple[str, Optional[List[Dict[str, Any]]]]:
+        """
+        Decode adaptive analysis payload from cache/results.
+
+        Returns a tuple of (analysis_markdown_or_raw, structured_chunks_or_none).
+        """
+        if payload is None:
+            return "", None
+        if isinstance(payload, str) and payload.strip().startswith("{"):
+            try:
+                envelope = json.loads(payload)
+            except json.JSONDecodeError:
+                return payload, None
+            if isinstance(envelope, dict) and "analysis" in envelope:
+                return str(envelope.get("analysis", payload)), envelope.get("structured_chunks")
+        return str(payload), None
         
     def run(self, file_path: str, vulnerability: Union[str, Dict], threshold: float = 0.7) -> str:
         """
@@ -1237,14 +1527,36 @@ class AdaptiveAnalysisPipeline:
                 # Use simplified scan prompt
                 scan_prompt = self.analyzer._build_scan_prompt(vuln_name, vuln_desc, chunk)
                 scan_result = self.analyzer._analyze_code_chunk(
-                    scan_prompt, file_path, chunk, vuln_name, 
+                    scan_prompt,
+                    file_path,
+                    chunk,
+                    vuln_name,
                     mode=AnalysisMode.SCAN,
-                    analysis_type=AnalysisType.ADAPTIVE
+                    analysis_type=AnalysisType.ADAPTIVE,
+                    ollama_json_format=ScanVerdict.model_json_schema(),
+                    response_model=ScanVerdict,
                 )
-                
-                # Add to suspicious chunks if flagged
-                if scan_result and scan_result.strip() == "SUSPICIOUS":
+
+                scan_verdict = str(scan_result).strip().upper() if scan_result is not None else ""
+                if not scan_verdict:
+                    logger.warning(
+                        f"Empty adaptive scan verdict for chunk {i + 1} in {file_path}; treating as ERROR"
+                    )
+                    scan_verdict = "ERROR"
+                if scan_verdict == "SUSPICIOUS":
                     final_suspicious_chunks.append((i, chunk))
+                elif scan_verdict == "ERROR":
+                    logger.warning(
+                        f"Adaptive scan verdict validation failed for chunk {i + 1} in {file_path}; continuing"
+                    )
+                elif scan_verdict == "CLEAN":
+                    logger.debug(
+                        f"Adaptive scan verdict CLEAN for chunk {i + 1} in {file_path}"
+                    )
+                else:
+                    logger.warning(
+                        f"Unexpected adaptive scan verdict '{scan_verdict}' for chunk {i + 1} in {file_path}; treating as CLEAN"
+                    )
                 
                 pbar.update(1)
         
@@ -1310,6 +1622,7 @@ class AdaptiveAnalysisPipeline:
         with tqdm(total=len(context_chunks), desc="Medium-depth analysis", leave=False) as pbar:
             for idx, (chunk_idx, chunk_text) in enumerate(context_chunks):
                 # Build a more detailed prompt than the scan prompt, but less detailed than deep analysis
+                schema_hint = json.dumps(MediumRiskAnalysis.model_json_schema(), indent=2)
                 prompt = f"""You are a security analyst specialized in {vuln_name} vulnerabilities.
 
 VULNERABILITY INFORMATION:
@@ -1324,49 +1637,40 @@ CODE TO ANALYZE:
 
 INSTRUCTIONS:
 1. Analyze this code ONLY for {vuln_name} vulnerabilities
-2. Provide a brief analysis (max 3 sentences)
-3. Rate the risk level from 0-100 where:
-   - 0-25: No risk or very low risk
-   - 26-50: Low risk
-   - 51-75: Medium risk
-   - 76-100: High risk
-4. Format your response EXACTLY as follows:
-RISK_SCORE: [number]
-ANALYSIS: [brief analysis]
+2. Provide a brief analysis (max 3 sentences) in field "analysis"
+3. Set "risk_score" from 0-100 (0-25 none/very low, 26-50 low, 51-75 medium, 76-100 high)
 
-DO NOT include any other text in your response.
+Respond with JSON only matching this schema (no markdown fences):
+{schema_hint}
 """
 
-                # Use the same model as scan but with different prompt
                 analysis_result = self.analyzer._analyze_code_chunk(
-                    prompt, file_path, chunk_text, vuln_name,
-                    mode=AnalysisMode.SCAN,  # Using scan model but with medium-depth prompt
-                    analysis_type=AnalysisType.ADAPTIVE
+                    prompt,
+                    file_path,
+                    chunk_text,
+                    vuln_name,
+                    mode=AnalysisMode.SCAN,
+                    analysis_type=AnalysisType.ADAPTIVE,
+                    ollama_json_format=MediumRiskAnalysis.model_json_schema(),
+                    response_model=MediumRiskAnalysis,
                 )
 
-                # Parse the result to extract risk score and analysis
-                risk_score = 0
-                analysis = ""
-
                 try:
-                    # Extract risk score
-                    if analysis_result and "RISK_SCORE:" in analysis_result:
-                        risk_line = [line for line in analysis_result.split('\n') if "RISK_SCORE:" in line][0]
-                        risk_score = int(re.search(r'RISK_SCORE:\s*(\d+)', risk_line)[1])
-
-                    # Extract analysis
-                    if analysis_result and "ANALYSIS:" in analysis_result:
-                        analysis_line = [line for line in analysis_result.split('\n') if "ANALYSIS:" in line][0]
-                        analysis = re.search(r'ANALYSIS:\s*(.*)', analysis_line)[1]
-                except Exception as e:
+                    medium = MediumRiskAnalysis.model_validate_json(analysis_result)
+                    risk_score = medium.risk_score
+                    analysis = medium.analysis
+                    validation_error = medium.validation_error
+                except ValidationError as e:
                     logger.warning(f"Error parsing medium analysis result: {str(e)}")
-                    risk_score = 50  # Default to medium risk if parsing fails
-                    analysis = "Error parsing analysis result"
+                    risk_score = 50
+                    analysis = "Error parsing analysis result (validation_error=True)"
+                    validation_error = True
 
                 results.append({
                     'chunk_idx': chunk_idx,
                     'risk_score': risk_score,
                     'analysis': analysis,
+                    'validation_error': validation_error,
                     'content': chunk_text
                 })
 
@@ -1389,11 +1693,16 @@ DO NOT include any other text in your response.
         """
         # Create a mapping from chunk_idx to risk score
         risk_map = {result['chunk_idx']: result['risk_score'] for result in medium_results}
+        validation_error_map = {
+            result['chunk_idx']: bool(result.get('validation_error', False))
+            for result in medium_results
+        }
         
         # Select high-risk chunks based on risk threshold
         high_risk_chunks = [
             (chunk_idx, chunk_text) for chunk_idx, chunk_text in suspicious_chunks
-            if risk_map.get(chunk_idx, 0) >= risk_threshold
+            if not validation_error_map.get(chunk_idx, False)
+            and risk_map.get(chunk_idx, 0) >= risk_threshold
         ]
         
         logger.debug(f"Identified {len(high_risk_chunks)}/{len(suspicious_chunks)} high-risk chunks")
@@ -1420,11 +1729,10 @@ DO NOT include any other text in your response.
         deep_results = []
         
         # Get common format requirements
-        common_prompt = _get_common_prompt(vuln_name)
-        
+        common_prompt = _get_structured_deep_instructions(vuln_name)
+
         with tqdm(total=len(high_risk_chunks), desc="Deep analysis of high-risk chunks", leave=False) as pbar:
             for chunk_idx, chunk_text in high_risk_chunks:
-                # Build comprehensive analysis prompt
                 prompt = f"""You are a cybersecurity expert specialized in {vuln_name} vulnerabilities ONLY.
 
 VULNERABILITY DETAILS:
@@ -1446,13 +1754,17 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
 {common_prompt}
 """
 
-                # Use deep model for comprehensive analysis
                 analysis_result = self.analyzer._analyze_code_chunk(
-                    prompt, file_path, chunk_text, vuln_name,
+                    prompt,
+                    file_path,
+                    chunk_text,
+                    vuln_name,
                     mode=AnalysisMode.DEEP,
-                    analysis_type=AnalysisType.ADAPTIVE
+                    analysis_type=AnalysisType.ADAPTIVE,
+                    ollama_json_format=ChunkDeepAnalysis.model_json_schema(),
+                    response_model=ChunkDeepAnalysis,
                 )
-                
+
                 deep_results.append({
                     'chunk_idx': chunk_idx,
                     'analysis': analysis_result,
@@ -1463,21 +1775,16 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
         
         return deep_results
 
-    def _combine_adaptive_results(self, file_path: str, code_chunks: List[str],
-                                suspicious_chunks: List[Tuple[int, str]],
-                                medium_results: List[Dict], deep_results: List[Dict]) -> str:
+    def _combine_adaptive_results(
+        self,
+        file_path: str,
+        code_chunks: List[str],
+        suspicious_chunks: List[Tuple[int, str]],
+        medium_results: List[Dict],
+        deep_results: List[Dict],
+    ) -> Dict[str, Any]:
         """
-        Combine results from different analysis levels into a comprehensive report.
-        
-        Args:
-            file_path: Path to the file being analyzed
-            code_chunks: All code chunks from the file
-            suspicious_chunks: All chunks identified as suspicious
-            medium_results: Results from medium-depth analysis
-            deep_results: Results from deep analysis
-            
-        Returns:
-            Combined analysis results as formatted string
+        Combine adaptive phases into markdown plus structured deep chunk payloads.
         """
         # Extract all chunk indices
         suspicious_indices = {idx for idx, _ in suspicious_chunks}
@@ -1489,11 +1796,67 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
         suspicious_count = len(suspicious_indices)
         medium_analyzed = len(medium_indices)
         deep_analyzed = len(deep_indices)
+        medium_validation_errors = len(
+            [result for result in medium_results if result.get("validation_error")]
+        )
         
-        # Identify vulnerable chunks (those with deep analysis that found vulnerabilities)
+        unparsed_deep_chunks: List[Dict[str, Any]] = []
+        suspect_deep_chunks: List[Dict[str, Any]] = []
+        parsed_deep_results: List[Dict[str, Any]] = []
+        structured_chunks: List[Dict[str, Any]] = []
+
+        for result in deep_results:
+            raw = result.get("analysis", "")
+            chunk_idx = result.get("chunk_idx", "unknown")
+            try:
+                chunk_model = ChunkDeepAnalysis.model_validate_json(raw)
+                parsed_deep_results.append({"result": result, "model": chunk_model})
+                structured_chunks.append(chunk_model.model_dump())
+            except Exception as exc:
+                self.analyzer._log_structured_output_error(
+                    phase="adaptive_deep_parse",
+                    response_model=ChunkDeepAnalysis,
+                    model_display=self.analyzer.ollama_manager.get_model_display_name(self.analyzer.llm_model),
+                    raw=raw,
+                    error=exc,
+                    file_path=file_path,
+                    chunk_index=chunk_idx if isinstance(chunk_idx, int) else None,
+                )
+                logger.warning(
+                    "Unable to parse deep analysis for chunk %s in %s: %s",
+                    chunk_idx,
+                    file_path,
+                    exc,
+                )
+                unparsed_deep_chunks.append(result)
+                suspect_deep_chunks.append(
+                    {
+                        "chunk_idx": chunk_idx,
+                        "validation_error": True,
+                        "potential_vulnerabilities": True,
+                        "reason": "deep_analysis_parse_failure",
+                    }
+                )
+                raw_text = raw or ""
+                notes = raw_text
+                if len(raw_text) > 4000:
+                    logger.warning(
+                        "Truncating deep analysis fallback notes for chunk %s from %s to 4000 characters",
+                        chunk_idx,
+                        len(raw_text),
+                    )
+                    notes = f"{raw_text[:4000]}... [truncated]"
+                structured_chunks.append(
+                    ChunkDeepAnalysis(
+                        findings=[],
+                        notes=notes,
+                        validation_error=True,
+                        potential_vulnerabilities=True,
+                    ).model_dump()
+                )
+
         vulnerable_chunks = [
-            result for result in deep_results 
-            if "No" not in result['analysis'] or "vulnerabilities found" not in result['analysis']
+            item for item in parsed_deep_results if item["model"].findings
         ]
 
         # 1. Summary section
@@ -1503,8 +1866,11 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
 - **Total code chunks analyzed**: {total_chunks}
 - **Suspicious chunks identified**: {suspicious_count} ({(suspicious_count/total_chunks*100):.1f}%)
 - **Context-sensitive chunks analyzed**: {medium_analyzed}
+- **Medium-analysis validation errors**: {medium_validation_errors}
 - **High-risk chunks deeply analyzed**: {deep_analyzed}
 - **Vulnerable chunks found**: {len(vulnerable_chunks)}
+- **Unparseable deep-analysis chunks**: {len(unparsed_deep_chunks)}
+- **Potential vulnerabilities (parse-failure suspects)**: {len(suspect_deep_chunks)}
 """
         report_parts = [summary]
         
@@ -1512,22 +1878,39 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
         if vulnerable_chunks:
             report_parts.append("\n## Identified Vulnerabilities\n")
 
-            for i, result in enumerate(vulnerable_chunks):
-                chunk_idx = result['chunk_idx']
-                analysis = result['analysis']
-
+            for i, item in enumerate(vulnerable_chunks):
+                result = item["result"]
+                chunk_model = item["model"]
+                chunk_idx = result["chunk_idx"]
+                analysis_body = chunk_analysis_to_markdown(chunk_model, chunk_idx)
                 section_header = f"### Vulnerability #{i+1} - Chunk {chunk_idx+1}\n"
-                report_parts.extend(
-                    (
-                        section_header + analysis,
-                        "\n<div class=\"page-break\"></div>\n",
-                    )
-                )
+                report_parts.extend((section_header + analysis_body, "\n<div class=\"page-break\"></div>\n"))
         else:
             report_parts.append("\n## No vulnerabilities were found in the deep analysis phase.\n")
 
-        # 3. Combine all parts
-        return "\n".join(report_parts)
+        if unparsed_deep_chunks:
+            report_parts.append("\n## Unparseable deep analyses\n")
+            for chunk in unparsed_deep_chunks:
+                chunk_idx = chunk.get("chunk_idx", "unknown")
+                raw = str(chunk.get("analysis", "") or "")
+                note = raw if len(raw) <= 300 else f"{raw[:300]}... [truncated]"
+                escaped_note = note.replace("```", "``\\`")
+                report_parts.append(
+                    "- Chunk {idx}: structured deep analysis could not be parsed.\n\n"
+                    "  Notes (raw model output, truncated & escaped):\n\n"
+                    "  ```\n"
+                    "{note}\n"
+                    "  ```\n".format(
+                        idx=chunk_idx,
+                        note=escaped_note,
+                    )
+                )
+
+        return {
+            "markdown": "\n".join(report_parts),
+            "structured_chunks": structured_chunks,
+            "suspect_deep_chunks": suspect_deep_chunks,
+        }
 
     def perform_adaptive_analysis(self, vulnerabilities, args, report):
         """
@@ -1637,20 +2020,23 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
             
             # Get analysis result from batch processor
             analysis = self._batch_processor.get_result(result_key)
-            
+            analysis, structured_chunks = self._decode_adaptive_envelope(analysis)
+
             if analysis and not analysis.startswith("Error") and not analysis.startswith("No results"):
-                # Format the result exactly as _process_files_adaptively did
-                detailed_results.append({
-                    'file_path': file_path,
-                    'similarity_score': similarity_score,
-                    'analysis': analysis,
-                    'vulnerability': {
-                        'name': vuln_name,
-                        'description': vuln.get('description', ''),
-                        'impact': vuln.get('impact', ''),
-                        'mitigation': vuln.get('mitigation', '')
-                    }
-                })
+                row = {
+                    "file_path": file_path,
+                    "similarity_score": similarity_score,
+                    "analysis": analysis,
+                    "vulnerability": {
+                        "name": vuln_name,
+                        "description": vuln.get("description", ""),
+                        "impact": vuln.get("impact", ""),
+                        "mitigation": vuln.get("mitigation", ""),
+                    },
+                }
+                if structured_chunks is not None:
+                    row["structured_chunks"] = structured_chunks
+                detailed_results.append(row)
         
         return detailed_results
 
@@ -1900,27 +2286,27 @@ class BatchAdaptiveAnalysis:
                 continue
                 
             try:
-                # Combine results
-                result = self.pipeline._combine_adaptive_results(
+                combined = self.pipeline._combine_adaptive_results(
                     file_path,
-                    data['code_chunks'],
-                    data['suspicious_chunks'],
-                    data['medium_results'],
-                    data['deep_results']
+                    data["code_chunks"],
+                    data["suspicious_chunks"],
+                    data["medium_results"],
+                    data["deep_results"],
                 )
-                
-                # Store result in memory
-                self.results[result_key] = result
-                
-                # Store result in cache using standard cache methods
+                serialized = self.pipeline._serialize_adaptive_envelope(
+                    markdown=combined["markdown"],
+                    structured_chunks=combined.get("structured_chunks", []),
+                )
+                self.results[result_key] = serialized
+
                 self.cache_manager.store_analysis(
                     file_path=file_path,
-                    chunk="",  # Placeholder for chunk
+                    chunk="",
                     vuln_name=vuln_name,
-                    prompt="",  # Placeholder for prompt
-                    result=result,
+                    prompt="",
+                    result=serialized,
                     mode=AnalysisMode.DEEP,
-                    analysis_type=AnalysisType.ADAPTIVE
+                    analysis_type=AnalysisType.ADAPTIVE,
                 )
                 
                 logger.debug(f"Stored adaptive analysis result in cache for {file_path} - {vuln_name}")
@@ -2195,27 +2581,27 @@ class BatchAdaptiveAnalysis:
                     try:
                         file_path, vuln_name = result_key
                         
-                        # Combine results using existing method
-                        result = self.pipeline._combine_adaptive_results(
+                        combined = self.pipeline._combine_adaptive_results(
                             file_path,
-                            data['code_chunks'],
-                            data['suspicious_chunks'],
-                            data['medium_results'],
-                            data['deep_results']
+                            data["code_chunks"],
+                            data["suspicious_chunks"],
+                            data["medium_results"],
+                            data["deep_results"],
                         )
-                        
-                        # Store result in memory
-                        self.results[result_key] = result
-                        
-                        # Store in cache
+                        serialized = self.pipeline._serialize_adaptive_envelope(
+                            markdown=combined["markdown"],
+                            structured_chunks=combined.get("structured_chunks", []),
+                        )
+                        self.results[result_key] = serialized
+
                         self.cache_manager.store_analysis(
                             file_path=file_path,
-                            chunk="",  # Placeholder for chunk
+                            chunk="",
                             vuln_name=vuln_name,
-                            prompt="",  # Placeholder for prompt
-                            result=result,
+                            prompt="",
+                            result=serialized,
                             mode=AnalysisMode.DEEP,
-                            analysis_type=AnalysisType.ADAPTIVE
+                            analysis_type=AnalysisType.ADAPTIVE,
                         )
                         
                     except Exception as e:
@@ -2226,55 +2612,40 @@ class BatchAdaptiveAnalysis:
     
     # All existing methods remain intact
 
-def _get_common_prompt(vuln_name: str) -> str:
+def _get_structured_deep_instructions(vuln_name: str) -> str:
     """
-    Generate common formatting instructions used in different prompts.
-    
-    Args:
-        vuln_name: Name of the vulnerability
-        
-    Returns:
-        Formatting instructions as a string
+    Instructions for structured JSON output (ChunkDeepAnalysis) aligned with prior Markdown intent.
     """
+    schema_hint = json.dumps(ChunkDeepAnalysis.model_json_schema(), indent=2)
     return f"""
-If you find {vuln_name} vulnerabilities:
-1. Quote the exact vulnerable code snippets related ONLY to {vuln_name}
-2. Explain specifically how this code is vulnerable to {vuln_name}
-3. Provide severity level (Critical/High/Medium/Low) for this {vuln_name} vulnerability
-4. Describe the potential impact specific to this {vuln_name} vulnerability
-5. Identify the application entry point and execution path:
-   - Determine the initial entry point (route, API endpoint, function or method)
-   - Create an ASCII flowchart showing the complete execution path from entry point to vulnerability
-   - Show all relevant functions/methods called in the execution chain
-6. Identify the complete attack/exploitation path:
-   - HTTP methods involved (GET, POST, PUT, DELETE)
-   - Specific parameters or variables that can be manipulated (form fields, URL parameters, headers)
-   - Step-by-step exploitation scenario with example payloads
-   - Any dependencies or conditions required for successful exploitation
-7. Provide detailed remediation recommendations with secure code examples
+Respond with a single JSON object matching this JSON Schema (no markdown code fences around the JSON):
+{schema_hint}
 
-FORMAT REQUIREMENTS:
-- Use Markdown formatting
-- For each {vuln_name} vulnerability found, delimitate clearly the previous section with a "Vulnerability found" title and then the vulnerable code block in a code fence
-- DO NOT MENTION any other vulnerability types besides {vuln_name}
-- Focus ONLY on {vuln_name} - this is extremely important
-- Step-by-step exploitation scenario with example payloads, including precise request methods (e.g., GET, POST) and explicit parameter names (e.g., 'user_id', 'token')
-- When providing the ASCII flowchart, make sure to do the following:
-  1. Begin with a header "## Execution Path"
-  2. Use a properly formatted code block with triple backticks (```) at the beginning AND end
-  3. Do not add any other content inside the code block besides the ASCII diagram
-  4. Format the ASCII diagram like this:
-  ```
-  Entry Point: /api/endpoint
-       |
-       v
-  [process_data]
-       |
-       v
-  [validate_input]
-       |
-       v
-  [parse_user_data] <-- Vulnerable Function
-  ```
-  5. After the closing triple backticks, continue with the next section
+Populate "findings" with one object per distinct {vuln_name} vulnerability in this chunk. If none, return {{"findings": [], "notes": "No issues"}}.
+
+Output constraints (strict):
+- Return JSON ONLY, exactly one object, no prose before or after.
+- Keep values concise to avoid truncation; prioritize complete valid JSON over verbosity.
+- Never repeat filler tokens (e.g. "the the the"), and never emit partial or unfinished strings.
+- Ensure the response ends with a fully closed JSON object (`}}` as appropriate).
+
+For each finding:
+- title: short label (e.g. "Vulnerability found")
+- vulnerable_code: exact snippet related ONLY to {vuln_name}
+- explanation: why it is vulnerable to {vuln_name} only
+- severity: one of Critical, High, Medium, Low
+- impact: potential impact for this {vuln_name} case
+- entry_point: route, API endpoint, function or method
+- execution_path_diagram: ASCII-only diagram text (no markdown headers inside this string)
+- http_methods: list of methods if applicable (e.g. GET, POST)
+- manipulable_parameters: parameter or header names
+- exploitation_steps: short bullet strings for the attack path
+- example_payloads: example strings if applicable
+- exploitation_conditions: dependencies or preconditions
+- remediation: remediation guidance
+- secure_code_example: optional secure code sample as plain text
+
+Rules:
+- DO NOT mention any vulnerability type other than {vuln_name}.
+- If no {vuln_name} issues exist, return an empty findings array.
 """

--- a/oasis/analyze.py
+++ b/oasis/analyze.py
@@ -15,7 +15,8 @@ from .config import CHUNK_ANALYZE_TIMEOUT, MODEL_EMOJIS, VULNERABILITY_PROMPT_EX
 
 # Import from other modules
 from .ollama_manager import OllamaManager
-from .tools import chunk_content, logger, calculate_similarity, sanitize_name
+from .snippet_lines import absolute_snippet_lines_in_file
+from .tools import chunk_content_with_spans, logger, calculate_similarity, sanitize_name
 from .report import Report
 from .embedding import EmbeddingManager, build_vulnerability_embedding_prompt
 from .cache import CacheManager
@@ -25,6 +26,7 @@ from .schemas.analysis import (
     ChunkDeepAnalysis,
     MediumRiskAnalysis,
     ScanVerdict,
+    VulnerabilityFinding,
     chunk_analysis_to_markdown,
 )
 from .structured_output.deep import (
@@ -41,6 +43,33 @@ from .structured_output.json_repair import (
 )
 
 STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN = 500
+
+
+def _enrich_findings_with_snippet_file_lines(
+    chunk_model: ChunkDeepAnalysis,
+    chunk_text: str,
+    file_chunk_start: Optional[int],
+) -> ChunkDeepAnalysis:
+    """Attach snippet_start_line/snippet_end_line when vulnerable_code matches the chunk."""
+    if not isinstance(file_chunk_start, int) or file_chunk_start < 1:
+        return chunk_model
+    new_findings: List[VulnerabilityFinding] = []
+    changed = False
+    for finding in chunk_model.findings:
+        span = absolute_snippet_lines_in_file(
+            chunk_text, file_chunk_start, finding.vulnerable_code
+        )
+        if span is None:
+            new_findings.append(finding)
+        else:
+            a, b = span
+            new_findings.append(
+                finding.model_copy(update={"snippet_start_line": a, "snippet_end_line": b})
+            )
+            changed = True
+    if not changed:
+        return chunk_model
+    return chunk_model.model_copy(update={"findings": new_findings})
 
 # Define analysis modes and types
 # Handler receives either ValidationError (schema mismatch) or runtime/transport exceptions.
@@ -457,8 +486,19 @@ class SecurityAnalyzer:
         logger.error(f"Invalid vulnerability type: {vulnerability}")
         return "", "", [], "", ""
 
-    def _build_analysis_prompt(self, vuln_name: str, vuln_desc: str, vuln_patterns: list,
-                               vuln_impact: str, vuln_mitigation: str, chunk_text: str, i: int, total_chunks: int) -> str:
+    def _build_analysis_prompt(
+        self,
+        vuln_name: str,
+        vuln_desc: str,
+        vuln_patterns: list,
+        vuln_impact: str,
+        vuln_mitigation: str,
+        chunk_text: str,
+        i: int,
+        total_chunks: int,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
+    ) -> str:
         """
         Construct the prompt for the LLM analysis.
         
@@ -486,6 +526,13 @@ class SecurityAnalyzer:
         
         common_prompt = _get_structured_deep_instructions(vuln_name)
 
+        location_note = ""
+        if start_line is not None and end_line is not None:
+            location_note = (
+                f"\nSOURCE LOCATION: This segment corresponds to lines {start_line}-{end_line} "
+                f"(1-based, inclusive) in the file under analysis.\n"
+            )
+
         return f"""You are a cybersecurity expert specialized in {vuln_name} vulnerabilities ONLY.
 
 CRITICAL INSTRUCTION: You must ONLY analyze the code for {vuln_name} vulnerabilities.
@@ -494,7 +541,7 @@ If you find other security issues, IGNORE them completely.
 
 VULNERABILITY DETAILS:
 {vuln_info}
-
+{location_note}
 CODE SEGMENT TO ANALYZE:
 ```
 {chunk_text}
@@ -600,7 +647,14 @@ Analyze this code segment ({i + 1}/{total_chunks}) for {vuln_name} vulnerabiliti
                 )
             return f"Error during chunk analysis: {e}"
 
-    def _build_scan_prompt(self, vuln_name: str, vuln_desc: str, chunk_text: str) -> str:
+    def _build_scan_prompt(
+        self,
+        vuln_name: str,
+        vuln_desc: str,
+        chunk_text: str,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
+    ) -> str:
         """
         Build a simplified prompt for initial scanning with lightweight models
         
@@ -612,9 +666,14 @@ Analyze this code segment ({i + 1}/{total_chunks}) for {vuln_name} vulnerabiliti
         Returns:
             Simplified prompt optimized for lightweight models
         """
+        location_note = ""
+        if start_line is not None and end_line is not None:
+            location_note = (
+                f"\nSOURCE LOCATION: Lines {start_line}-{end_line} (1-based, inclusive) in the file.\n"
+            )
         return f"""You are performing a preliminary security scan for {vuln_name} vulnerabilities.
 Description of vulnerability: {vuln_desc}
-
+{location_note}
 IMPORTANT INSTRUCTIONS:
 1. Analyze the code below for ONLY {vuln_name} vulnerabilities
 2. Return EXACTLY one JSON object and nothing else.
@@ -831,20 +890,27 @@ Code to analyze:
         """
         vuln_name, vuln_desc, _, _, _ = vuln_details
         
-        # Get the file content and chunk it
-        code = self.code_base[file_path]['content']
-        code_chunks = chunk_content(code, MAX_CHUNK_SIZE)
-        
+        # Get the file content and chunk it (with 1-based line spans per chunk)
+        code = self.code_base[file_path]["content"]
+        spanned = chunk_content_with_spans(code, MAX_CHUNK_SIZE)
+        code_chunks = [t[0] for t in spanned]
+
         # Initialize suspicious chunks for this file
         suspicious_chunks = []
-        
+
         # Scan each chunk with the lightweight model
-        with tqdm(total=len(code_chunks), 
-                desc=f"Chunks in {Path(file_path).name}", 
-                position=3, leave=False, disable=silent) as chunk_pbar:
-            for i, chunk in enumerate(code_chunks):
+        with tqdm(
+            total=len(code_chunks),
+            desc=f"Chunks in {Path(file_path).name}",
+            position=3,
+            leave=False,
+            disable=silent,
+        ) as chunk_pbar:
+            for i, (chunk, start_line, end_line) in enumerate(spanned):
                 # Use a simplified prompt for the scanning phase
-                scan_prompt = self._build_scan_prompt(vuln_name, vuln_desc, chunk)
+                scan_prompt = self._build_scan_prompt(
+                    vuln_name, vuln_desc, chunk, start_line=start_line, end_line=end_line
+                )
                 scan_result = self._analyze_code_chunk(
                     scan_prompt,
                     file_path,
@@ -863,7 +929,7 @@ Code to analyze:
                     )
                     scan_verdict = "ERROR"
                 if scan_verdict == "SUSPICIOUS":
-                    suspicious_chunks.append((i, chunk))
+                    suspicious_chunks.append((i, chunk, start_line, end_line))
                 elif scan_verdict == "ERROR":
                     logger.warning(
                         f"Structured scan verdict validation failed for chunk {i + 1} in {file_path}; continuing"
@@ -880,7 +946,7 @@ Code to analyze:
                 chunk_pbar.update(1)
         
         # Store indices for potential future use
-        self.suspicious_sections[(file_path, vuln_name)] = [idx for idx, _ in suspicious_chunks]
+        self.suspicious_sections[(file_path, vuln_name)] = [idx for idx, *_ in suspicious_chunks]
         
         return suspicious_chunks
     
@@ -1004,11 +1070,19 @@ Code to analyze:
         with tqdm(total=len(suspicious_chunks), 
                  desc=f"Chunks in {Path(file_path).name}", 
                  position=3, leave=False, disable=silent) as chunk_pbar:
-            for chunk_idx, chunk in suspicious_chunks:
+            for chunk_idx, chunk, start_line, end_line in suspicious_chunks:
                 # Build a detailed prompt for deep analysis
                 prompt = self._build_analysis_prompt(
-                    vuln_name, vuln_desc, vuln_patterns, vuln_impact, vuln_mitigation, 
-                    chunk, chunk_idx, len(suspicious_chunks)
+                    vuln_name,
+                    vuln_desc,
+                    vuln_patterns,
+                    vuln_impact,
+                    vuln_mitigation,
+                    chunk,
+                    chunk_idx,
+                    len(suspicious_chunks),
+                    start_line=start_line,
+                    end_line=end_line,
                 )
 
                 # Analyze with the deep model
@@ -1023,7 +1097,13 @@ Code to analyze:
                     response_model=ChunkDeepAnalysis,
                 )
                 try:
-                    analyses.append(ChunkDeepAnalysis.model_validate_json(analysis_result))
+                    validated = ChunkDeepAnalysis.model_validate_json(analysis_result)
+                    merged = validated.model_copy(
+                        update={"start_line": start_line, "end_line": end_line}
+                    )
+                    analyses.append(
+                        _enrich_findings_with_snippet_file_lines(merged, chunk, start_line)
+                    )
                 except ValidationError as exc:
                     self._log_structured_output_error(
                         phase="deep",
@@ -1036,7 +1116,12 @@ Code to analyze:
                         chunk_index=chunk_idx,
                     )
                     analyses.append(
-                        ChunkDeepAnalysis(findings=[], notes=f"Invalid chunk JSON: {analysis_result[:500]}")
+                        ChunkDeepAnalysis(
+                            findings=[],
+                            notes=f"Invalid chunk JSON: {analysis_result[:500]}",
+                            start_line=start_line,
+                            end_line=end_line,
+                        )
                     )
                 chunk_pbar.update(1)
 
@@ -1652,16 +1737,22 @@ class AdaptiveAnalysisPipeline:
         # Submit task to batch processor
         return self._batch_processor.submit_task(task)
 
-    def _static_pattern_analysis(self, code_chunks: List[str], vuln_patterns: List[str]) -> List[Tuple[int, str]]:
+    def _static_pattern_analysis(
+        self,
+        code_chunks: List[str],
+        vuln_patterns: List[str],
+        line_spans: List[Tuple[int, int]],
+    ) -> List[Tuple[int, str, int, int]]:
         """
         Perform fast pattern-based static analysis on code chunks.
         
         Args:
             code_chunks: List of code chunks
             vuln_patterns: List of vulnerability patterns to look for
+            line_spans: Parallel list of (start_line, end_line) per chunk index (1-based inclusive)
             
         Returns:
-            List of potentially suspicious chunks with their indices
+            List of potentially suspicious chunks with their indices and source line spans
         """
         suspicious_chunks = []
         
@@ -1674,7 +1765,8 @@ class AdaptiveAnalysisPipeline:
                 # TODO: Add more patterns
                 for pattern in vuln_patterns:
                     if pattern and pattern.lower() in chunk_lower:
-                        suspicious_chunks.append((i, chunk))
+                        sl, el = line_spans[i]
+                        suspicious_chunks.append((i, chunk, sl, el))
                         break
                 
                 pbar.update(1)
@@ -1682,9 +1774,15 @@ class AdaptiveAnalysisPipeline:
         logger.debug(f"Static analysis identified {len(suspicious_chunks)}/{len(code_chunks)} suspicious chunks")
         return suspicious_chunks
     
-    def _lightweight_model_scan(self, file_path: str, code_chunks: List[str], 
-                              static_suspicious_chunks: List[Tuple[int, str]], 
-                              vuln_name: str, vuln_desc: str) -> List[Tuple[int, str]]:
+    def _lightweight_model_scan(
+        self,
+        file_path: str,
+        code_chunks: List[str],
+        static_suspicious_chunks: List[Tuple[int, str, int, int]],
+        line_spans: List[Tuple[int, int]],
+        vuln_name: str,
+        vuln_desc: str,
+    ) -> List[Tuple[int, str, int, int]]:
         """
         Scan code chunks with lightweight model.
         
@@ -1699,16 +1797,19 @@ class AdaptiveAnalysisPipeline:
             Updated list of suspicious chunks
         """
         # Create a set of indices of chunks already identified as suspicious
-        suspicious_indices = {i for i, _ in static_suspicious_chunks}
-        final_suspicious_chunks = static_suspicious_chunks.copy()
+        suspicious_indices = {i for i, *_ in static_suspicious_chunks}
+        final_suspicious_chunks = list(static_suspicious_chunks)
         
         # Only scan chunks not already identified as suspicious
         remaining_chunks = [(i, chunk) for i, chunk in enumerate(code_chunks) if i not in suspicious_indices]
         
         with tqdm(total=len(remaining_chunks), desc="Lightweight model scan", leave=False) as pbar:
             for i, chunk in remaining_chunks:
+                sl, el = line_spans[i]
                 # Use simplified scan prompt
-                scan_prompt = self.analyzer._build_scan_prompt(vuln_name, vuln_desc, chunk)
+                scan_prompt = self.analyzer._build_scan_prompt(
+                    vuln_name, vuln_desc, chunk, start_line=sl, end_line=el
+                )
                 scan_result = self.analyzer._analyze_code_chunk(
                     scan_prompt,
                     file_path,
@@ -1727,7 +1828,7 @@ class AdaptiveAnalysisPipeline:
                     )
                     scan_verdict = "ERROR"
                 if scan_verdict == "SUSPICIOUS":
-                    final_suspicious_chunks.append((i, chunk))
+                    final_suspicious_chunks.append((i, chunk, sl, el))
                 elif scan_verdict == "ERROR":
                     logger.warning(
                         f"Adaptive scan verdict validation failed for chunk {i + 1} in {file_path}; continuing"
@@ -1746,7 +1847,9 @@ class AdaptiveAnalysisPipeline:
         logger.debug(f"After lightweight scan: {len(final_suspicious_chunks)}/{len(code_chunks)} suspicious chunks")
         return final_suspicious_chunks
     
-    def _identify_context_sensitive_chunks(self, suspicious_chunks: List[Tuple[int, str]], vuln_name: str) -> List[Tuple[int, str]]:
+    def _identify_context_sensitive_chunks(
+        self, suspicious_chunks: List[Tuple[int, str, int, int]], vuln_name: str
+    ) -> List[Tuple[int, str, int, int]]:
         """
         Identify chunks that require context-sensitive analysis.
         
@@ -1768,13 +1871,13 @@ class AdaptiveAnalysisPipeline:
         ]
         
         with tqdm(total=len(suspicious_chunks), desc="Identifying context-sensitive chunks", leave=False) as pbar:
-            for chunk_idx, chunk_text in suspicious_chunks:
+            for chunk_idx, chunk_text, start_line, end_line in suspicious_chunks:
                 chunk_lower = chunk_text.lower()
                 
                 # Check for context patterns
                 for pattern in context_patterns:
                     if pattern in chunk_lower:
-                        context_sensitive_chunks.append((chunk_idx, chunk_text))
+                        context_sensitive_chunks.append((chunk_idx, chunk_text, start_line, end_line))
                         break
                 
                 pbar.update(1)
@@ -1782,9 +1885,16 @@ class AdaptiveAnalysisPipeline:
         logger.debug(f"Identified {len(context_sensitive_chunks)}/{len(suspicious_chunks)} context-sensitive chunks")
         return context_sensitive_chunks
     
-    def _medium_model_analysis(self, file_path: str, context_chunks: List[Tuple[int, str]], 
-                               vuln_name: str, vuln_desc: str, vuln_patterns: List[str],
-                               vuln_impact: str, vuln_mitigation: str) -> List[Dict]:
+    def _medium_model_analysis(
+        self,
+        file_path: str,
+        context_chunks: List[Tuple[int, str, int, int]],
+        vuln_name: str,
+        vuln_desc: str,
+        vuln_patterns: List[str],
+        vuln_impact: str,
+        vuln_mitigation: str,
+    ) -> List[Dict]:
         """
         Perform medium-depth analysis on context-sensitive chunks.
         
@@ -1803,7 +1913,7 @@ class AdaptiveAnalysisPipeline:
         results = []
 
         with tqdm(total=len(context_chunks), desc="Medium-depth analysis", leave=False) as pbar:
-            for idx, (chunk_idx, chunk_text) in enumerate(context_chunks):
+            for idx, (chunk_idx, chunk_text, _sl, _el) in enumerate(context_chunks):
                 # Build a more detailed prompt than the scan prompt, but less detailed than deep analysis
                 schema_hint = json.dumps(MediumRiskAnalysis.model_json_schema(), indent=2)
                 prompt = f"""You are a security analyst specialized in {vuln_name} vulnerabilities.
@@ -1861,8 +1971,12 @@ Respond with JSON only matching this schema (no markdown fences):
 
         return results
     
-    def _identify_high_risk_chunks(self, suspicious_chunks: List[Tuple[int, str]], 
-                               medium_results: List[Dict], risk_threshold: int = 70) -> List[Tuple[int, str]]:
+    def _identify_high_risk_chunks(
+        self,
+        suspicious_chunks: List[Tuple[int, str, int, int]],
+        medium_results: List[Dict],
+        risk_threshold: int = 70,
+    ) -> List[Tuple[int, str, int, int]]:
         """
         Identify high-risk chunks that need deep analysis.
         
@@ -1883,7 +1997,8 @@ Respond with JSON only matching this schema (no markdown fences):
         
         # Select high-risk chunks based on risk threshold
         high_risk_chunks = [
-            (chunk_idx, chunk_text) for chunk_idx, chunk_text in suspicious_chunks
+            (chunk_idx, chunk_text, start_line, end_line)
+            for chunk_idx, chunk_text, start_line, end_line in suspicious_chunks
             if not validation_error_map.get(chunk_idx, False)
             and risk_map.get(chunk_idx, 0) >= risk_threshold
         ]
@@ -1891,9 +2006,16 @@ Respond with JSON only matching this schema (no markdown fences):
         logger.debug(f"Identified {len(high_risk_chunks)}/{len(suspicious_chunks)} high-risk chunks")
         return high_risk_chunks
 
-    def _deep_model_analysis(self, file_path: str, high_risk_chunks: List[Tuple[int, str]],
-                            vuln_name: str, vuln_desc: str, vuln_patterns: List[str],
-                            vuln_impact: str, vuln_mitigation: str) -> List[Dict]:
+    def _deep_model_analysis(
+        self,
+        file_path: str,
+        high_risk_chunks: List[Tuple[int, str, int, int]],
+        vuln_name: str,
+        vuln_desc: str,
+        vuln_patterns: List[str],
+        vuln_impact: str,
+        vuln_mitigation: str,
+    ) -> List[Dict]:
         """
         Perform deep analysis on high-risk chunks.
         
@@ -1915,7 +2037,12 @@ Respond with JSON only matching this schema (no markdown fences):
         common_prompt = _get_structured_deep_instructions(vuln_name)
 
         with tqdm(total=len(high_risk_chunks), desc="Deep analysis of high-risk chunks", leave=False) as pbar:
-            for chunk_idx, chunk_text in high_risk_chunks:
+            for chunk_idx, chunk_text, start_line, end_line in high_risk_chunks:
+                location_note = ""
+                if start_line is not None and end_line is not None:
+                    location_note = (
+                        f"\nSOURCE LOCATION: Lines {start_line}-{end_line} (1-based, inclusive) in the file.\n"
+                    )
                 prompt = f"""You are a cybersecurity expert specialized in {vuln_name} vulnerabilities ONLY.
 
 VULNERABILITY DETAILS:
@@ -1924,7 +2051,7 @@ VULNERABILITY DETAILS:
 - Common patterns: {', '.join(vuln_patterns) if vuln_patterns else 'N/A'}
 - Security impact: {vuln_impact}
 - Mitigation: {vuln_mitigation}
-
+{location_note}
 CODE SEGMENT TO ANALYZE:
 
 ```
@@ -1948,11 +2075,15 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
                     response_model=ChunkDeepAnalysis,
                 )
 
-                deep_results.append({
-                    'chunk_idx': chunk_idx,
-                    'analysis': analysis_result,
-                    'content': chunk_text
-                })
+                deep_results.append(
+                    {
+                        "chunk_idx": chunk_idx,
+                        "analysis": analysis_result,
+                        "content": chunk_text,
+                        "start_line": start_line,
+                        "end_line": end_line,
+                    }
+                )
                 
                 pbar.update(1)
         
@@ -1962,7 +2093,7 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
         self,
         file_path: str,
         code_chunks: List[str],
-        suspicious_chunks: List[Tuple[int, str]],
+        suspicious_chunks: List[Tuple[int, str, int, int]],
         medium_results: List[Dict],
         deep_results: List[Dict],
     ) -> Dict[str, Any]:
@@ -1970,7 +2101,7 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
         Combine adaptive phases into markdown plus structured deep chunk payloads.
         """
         # Extract all chunk indices
-        suspicious_indices = {idx for idx, _ in suspicious_chunks}
+        suspicious_indices = {idx for idx, *_ in suspicious_chunks}
         medium_indices = {result['chunk_idx'] for result in medium_results}
         deep_indices = {result['chunk_idx'] for result in deep_results}
         
@@ -1991,8 +2122,18 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
         for result in deep_results:
             raw = result.get("analysis", "")
             chunk_idx = result.get("chunk_idx", "unknown")
+            sl, el = result.get("start_line"), result.get("end_line")
             try:
                 chunk_model = ChunkDeepAnalysis.model_validate_json(raw)
+                if isinstance(sl, int) and isinstance(el, int):
+                    chunk_model = chunk_model.model_copy(update={"start_line": sl, "end_line": el})
+                chunk_text = result.get("content") or ""
+                if isinstance(chunk_text, str):
+                    chunk_model = _enrich_findings_with_snippet_file_lines(
+                        chunk_model,
+                        chunk_text,
+                        sl if isinstance(sl, int) else None,
+                    )
                 parsed_deep_results.append({"result": result, "model": chunk_model})
                 structured_chunks.append(chunk_model.model_dump())
             except Exception as exc:
@@ -2029,12 +2170,16 @@ Analyze this code segment for {vuln_name} vulnerabilities ONLY.
                         len(raw_text),
                     )
                     notes = f"{raw_text[:4000]}... [truncated]"
+                fb_sl = result.get("start_line") if isinstance(result.get("start_line"), int) else None
+                fb_el = result.get("end_line") if isinstance(result.get("end_line"), int) else None
                 structured_chunks.append(
                     ChunkDeepAnalysis(
                         findings=[],
                         notes=notes,
                         validation_error=True,
                         potential_vulnerabilities=True,
+                        start_line=fb_sl,
+                        end_line=fb_el,
                     ).model_dump()
                 )
 
@@ -2340,16 +2485,21 @@ class BatchAdaptiveAnalysis:
                     continue
                 
                 # Static analysis phase
-                code = self.code_base[file_path]['content']
-                code_chunks = chunk_content(code, MAX_CHUNK_SIZE)
-                
+                code = self.code_base[file_path]["content"]
+                spanned = chunk_content_with_spans(code, MAX_CHUNK_SIZE)
+                code_chunks = [t[0] for t in spanned]
+                line_spans = [(t[1], t[2]) for t in spanned]
+
                 logger.debug(f"PHASE 1: Static pattern analysis for {file_path} - {vuln_name}")
-                suspicious_chunks = self.pipeline._static_pattern_analysis(code_chunks, vuln_patterns)
-                
+                suspicious_chunks = self.pipeline._static_pattern_analysis(
+                    code_chunks, vuln_patterns, line_spans
+                )
+
                 # Store results for next phases
                 self.analysis_data[(file_path, vuln_name)] = {
                     'file_path': file_path,
                     'code_chunks': code_chunks,
+                    'line_spans': line_spans,
                     'suspicious_chunks': suspicious_chunks,
                     'vuln_data': vulnerability,
                     'vuln_details': (vuln_name, vuln_desc, vuln_patterns, vuln_impact, vuln_mitigation),
@@ -2391,7 +2541,12 @@ class BatchAdaptiveAnalysis:
                 # Only scan if static analysis filtered enough chunks
                 if len(suspicious_chunks) < len(code_chunks) * threshold:
                     suspicious_chunks = self.pipeline._lightweight_model_scan(
-                        file_path, code_chunks, suspicious_chunks, vuln_details[0], vuln_details[1]
+                        file_path,
+                        code_chunks,
+                        suspicious_chunks,
+                        data["line_spans"],
+                        vuln_details[0],
+                        vuln_details[1],
                     )
                     # Update suspicious chunks
                     self.analysis_data[(file_path, vuln_name)]['suspicious_chunks'] = suspicious_chunks
@@ -2590,15 +2745,20 @@ class BatchAdaptiveAnalysis:
                         continue
 
                     # Static analysis phase - always perform regardless of cache
-                    code = self.code_base[file_path]['content']
-                    code_chunks = chunk_content(code, MAX_CHUNK_SIZE)
+                    code = self.code_base[file_path]["content"]
+                    spanned = chunk_content_with_spans(code, MAX_CHUNK_SIZE)
+                    code_chunks = [t[0] for t in spanned]
+                    line_spans = [(t[1], t[2]) for t in spanned]
 
-                    suspicious_chunks = self.pipeline._static_pattern_analysis(code_chunks, vuln_patterns)
+                    suspicious_chunks = self.pipeline._static_pattern_analysis(
+                        code_chunks, vuln_patterns, line_spans
+                    )
 
                     # Store results for next phases
                     self.analysis_data[result_key] = {
                         'file_path': file_path,
                         'code_chunks': code_chunks,
+                        'line_spans': line_spans,
                         'suspicious_chunks': suspicious_chunks,
                         'vuln_data': vulnerability,
                         'vuln_details': (vuln_name, vuln_desc, vuln_patterns, vuln_impact, vuln_mitigation),
@@ -2656,7 +2816,12 @@ class BatchAdaptiveAnalysis:
                     # Only scan if static analysis didn't find enough
                     if len(suspicious_chunks) < len(code_chunks) * threshold:
                         suspicious_chunks = self.pipeline._lightweight_model_scan(
-                            file_path, code_chunks, suspicious_chunks, vuln_details[0], vuln_details[1]
+                            file_path,
+                            code_chunks,
+                            suspicious_chunks,
+                            data["line_spans"],
+                            vuln_details[0],
+                            vuln_details[1],
                         )
                         # Update suspicious chunks
                         self.analysis_data[result_key]['suspicious_chunks'] = suspicious_chunks

--- a/oasis/analyze.py
+++ b/oasis/analyze.py
@@ -1,6 +1,8 @@
 import argparse
 import json
+import logging
 import re
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
@@ -24,6 +26,18 @@ from .schemas.analysis import (
     MediumRiskAnalysis,
     ScanVerdict,
     chunk_analysis_to_markdown,
+)
+from .structured_output.deep import (
+    chunk_deep_normalization_change_samples,
+    chunk_deep_prompt_output_constraint_block,
+    chunk_deep_structured_retry_suffix,
+    generic_structured_retry_suffix,
+    normalize_chunk_deep_payload_dict,
+    validation_detail_is_exploitation_conditions_retryable,
+)
+from .structured_output.json_repair import (
+    build_safe_minimal_chunk_json,
+    repair_chunk_deep_structured_json_raw,
 )
 
 STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN = 500
@@ -151,16 +165,43 @@ class SecurityAnalyzer:
         - Scan models return a plain verdict string.
         - Non-scan models return JSON serialized by the target Pydantic schema.
         - Validation failures are converted through the structured fallback strategy.
+
+        **Raw variables (ChunkDeep / scan JSON path):**
+
+        - ``original_raw``: immutable copy of the model string for logging and for the
+          structured failure handler (so diagnostics always show what the API returned).
+        - ``candidate_raw``: text passed to ``model_validate_json`` — starts as
+          normalized output (e.g. list→string coercion for ChunkDeep); may be replaced by
+          ``repaired_raw`` when JSON repair succeeds after a repairable parse error.
+        - ``repaired_raw``: optional output of ``_repair_structured_json_raw`` when the
+          first validation error looks like broken JSON (not a field-type mismatch);
+          used only to retry validation, not as the logged ``original_raw``.
         """
+        original_raw = raw
+        candidate_raw = self._normalize_structured_output_raw(
+            raw=raw,
+            response_model=response_model,
+            model_display=model_display,
+        )
         try:
-            parsed = response_model.model_validate_json(raw)
+            parsed = response_model.model_validate_json(candidate_raw)
         except ValidationError as exc:
+            candidate_raw, repaired_parsed = self._attempt_structured_json_repair_after_validation_error(
+                candidate_raw=candidate_raw,
+                response_model=response_model,
+                model_display=model_display,
+                error=exc,
+            )
+            if repaired_parsed is not None:
+                if issubclass(response_model, ScanVerdict):
+                    return repaired_parsed.verdict
+                return repaired_parsed.model_dump_json()
             phase_name = "scan" if issubclass(response_model, ScanVerdict) else "deep"
             self._log_structured_output_error(
                 phase=phase_name,
                 response_model=response_model,
                 model_display=model_display,
-                raw=raw,
+                raw=original_raw,
                 error=exc,
                 file_path=file_path,
                 vuln_name=vuln_name,
@@ -168,15 +209,15 @@ class SecurityAnalyzer:
                 retry_max=retry_max,
             )
             logger.warning(f"Structured output validation failed ({model_display}): {exc}")
-            raw_preview = (raw or "")[:STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN]
-            if len(raw or "") > STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN:
+            raw_preview = (original_raw or "")[:STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN]
+            if len(original_raw or "") > STRUCTURED_OUTPUT_RAW_PREVIEW_MAX_LEN:
                 raw_preview += "... [truncated]"
             logger.debug(f"Structured output raw preview ({model_display}): {raw_preview}")
             if raise_validation_error:
                 raise
             return self._resolve_structured_output_failure(
                 response_model=response_model,
-                raw=raw,
+                raw=original_raw,
                 error=exc,
                 model_display=model_display,
             )
@@ -184,6 +225,147 @@ class SecurityAnalyzer:
         if issubclass(response_model, ScanVerdict):
             return parsed.verdict
         return parsed.model_dump_json()
+
+    def _attempt_structured_json_repair_after_validation_error(
+        self,
+        *,
+        candidate_raw: str,
+        response_model: Type[BaseModel],
+        model_display: str,
+        error: ValidationError,
+    ) -> Tuple[str, Optional[BaseModel]]:
+        """
+        When validation failed, optionally run JSON repair and re-parse.
+
+        Returns ``(candidate_raw, None)`` if repair is not applicable or did not help.
+        On success returns ``(repaired_raw, parsed_model)`` so the caller can serialize
+        the repaired object without re-running repair.
+        """
+        if not self._is_repairable_structured_error(error=error):
+            return candidate_raw, None
+        repaired_raw = self._repair_structured_json_raw(
+            raw=candidate_raw,
+            response_model=response_model,
+            model_display=model_display,
+        )
+        if repaired_raw == candidate_raw:
+            return candidate_raw, None
+        with suppress(ValidationError):
+            repaired_parsed = response_model.model_validate_json(repaired_raw)
+            return repaired_raw, repaired_parsed
+        return candidate_raw, None
+
+    def _normalize_structured_output_raw(
+        self,
+        *,
+        raw: str,
+        response_model: Type[BaseModel],
+        model_display: str,
+    ) -> str:
+        """Normalize frequent non-breaking type drifts before schema validation."""
+        if not raw or not issubclass(response_model, ChunkDeepAnalysis):
+            return raw
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.debug(
+                "Structured output normalization skipped: JSON parse failed (%s): %s",
+                model_display,
+                exc,
+            )
+            return raw
+        except (TypeError, ValueError) as exc:
+            logger.debug(
+                "Structured output normalization skipped: not valid JSON input (%s): %s",
+                model_display,
+                exc,
+            )
+            return raw
+
+        if not isinstance(payload, dict):
+            logger.debug(
+                "Structured output normalization skipped: payload is %s, not a dict (%s)",
+                type(payload).__name__,
+                model_display,
+            )
+            return raw
+
+        normalized_fields = normalize_chunk_deep_payload_dict(payload)
+        if not normalized_fields:
+            return raw
+
+        if logger.isEnabledFor(logging.DEBUG):
+            # Second parse of ``raw`` avoids a deep copy of the mutated tree; ``raw`` is the
+            # canonical pre-normalization snapshot (same as the initial ``json.loads`` source).
+            payload_before = json.loads(raw)
+            samples = chunk_deep_normalization_change_samples(
+                payload_before, payload, max_items=5
+            )
+            sample_json = json.dumps(samples, ensure_ascii=True, default=str)
+            if len(sample_json) > 800:
+                sample_json = sample_json[:800] + "... [truncated]"
+            logger.debug(
+                "Normalized structured output fields (%s): %s; sample_changes=%s",
+                model_display,
+                ", ".join(normalized_fields),
+                sample_json,
+            )
+        else:
+            logger.debug(
+                "Normalized structured output fields (%s): %s",
+                model_display,
+                ", ".join(normalized_fields),
+            )
+        return json.dumps(payload)
+
+    @staticmethod
+    def _is_repairable_structured_error(error: Exception) -> bool:
+        """
+        Return True when JSON repair heuristics are worth attempting.
+
+        We only treat Pydantic ``ValidationError`` details that indicate the *payload*
+        failed JSON decoding (not a mere schema field mismatch). Examples:
+        - ``{"type": "json_invalid", ...}`` from ``model_validate_json`` on bad syntax.
+        - ``msg`` containing ``eof while parsing`` (truncated JSON).
+        - ``msg`` mentioning ``trailing comma`` (invalid JSON extension some models emit).
+        """
+        if not isinstance(error, ValidationError):
+            return False
+        for detail in error.errors():
+            err_type = str(detail.get("type", ""))
+            # Example: model_validate_json('{"a":') -> json_invalid
+            if "json_invalid" in err_type:
+                return True
+            message = str(detail.get("msg", "")).lower()
+            if "eof while parsing" in message or "trailing comma" in message:
+                return True
+        return False
+
+    def _repair_structured_json_raw(
+        self,
+        *,
+        raw: str,
+        response_model: Type[BaseModel],
+        model_display: str,
+    ) -> str:
+        """
+        Repair ChunkDeepAnalysis JSON only; other response models are returned unchanged.
+
+        Low-level parsing lives in :mod:`oasis.structured_output.json_repair`.
+        """
+        if not raw or not issubclass(response_model, ChunkDeepAnalysis):
+            return raw
+        return repair_chunk_deep_structured_json_raw(raw, model_display=model_display)
+
+    @staticmethod
+    def _build_safe_minimal_chunk_json(raw: str) -> Optional[str]:
+        """
+        Thin wrapper for tests; delegates to ``oasis.structured_output.json_repair``.
+
+        Intended only for ChunkDeepAnalysis fallback payloads.
+        """
+        return build_safe_minimal_chunk_json(raw)
 
     def _log_structured_output_error(
         self,
@@ -233,11 +415,18 @@ class SecurityAnalyzer:
         message = str(error)
         if issubclass(response_model, ScanVerdict):
             return "Field required" in message and "verdict" in message
+        if issubclass(response_model, ChunkDeepAnalysis) and isinstance(error, ValidationError):
+            for detail in error.errors():
+                if validation_detail_is_exploitation_conditions_retryable(detail):
+                    return True
         return "json_invalid" in message or "EOF while parsing" in message
 
     def _get_structured_retry_limit(self, response_model: Type[BaseModel]) -> int:
         """Bound retry count per structured model type."""
-        return 2 if issubclass(response_model, ScanVerdict) else 1
+        return 2 if (
+            issubclass(response_model, ScanVerdict)
+            or issubclass(response_model, ChunkDeepAnalysis)
+        ) else 1
 
     def _build_structured_retry_suffix(self, response_model: Type[BaseModel]) -> str:
         """Build minimal correction reminder appended to the prompt on retry."""
@@ -248,12 +437,9 @@ class SecurityAnalyzer:
                 "Do NOT output schema keys (description/properties/required/title/type).\n"
                 "Do NOT use markdown code fences.\n"
             )
-        return (
-            "\n\nCORRECTION: Return valid JSON only (single object matching the required schema).\n"
-            "Do NOT use markdown code fences.\n"
-            "Return compact JSON with no explanations, no repeated filler tokens, and no trailing commentary.\n"
-            "Ensure every quote/bracket is closed and output ends with the final '}' of the JSON object.\n"
-        )
+        if issubclass(response_model, ChunkDeepAnalysis):
+            return chunk_deep_structured_retry_suffix()
+        return generic_structured_retry_suffix()
         
     def _get_vulnerability_details(self, vulnerability: Union[str, Dict]) -> Tuple[str, str, list, str, str]:
         """
@@ -623,9 +809,6 @@ Code to analyze:
                         file_pbar.update(1)
 
                 vuln_scan_pbar.update(1)
-                
-                if main_pbar:
-                    main_pbar.update(0.5)
 
         return {
             'suspicious_data': all_suspicious_data,
@@ -752,7 +935,7 @@ Code to analyze:
                 # Update progress bars
                 deep_vuln_pbar.update(1)
                 if main_pbar:
-                    main_pbar.update(0.5)
+                    main_pbar.update(1)
 
         return all_results
     
@@ -2623,11 +2806,7 @@ Respond with a single JSON object matching this JSON Schema (no markdown code fe
 
 Populate "findings" with one object per distinct {vuln_name} vulnerability in this chunk. If none, return {{"findings": [], "notes": "No issues"}}.
 
-Output constraints (strict):
-- Return JSON ONLY, exactly one object, no prose before or after.
-- Keep values concise to avoid truncation; prioritize complete valid JSON over verbosity.
-- Never repeat filler tokens (e.g. "the the the"), and never emit partial or unfinished strings.
-- Ensure the response ends with a fully closed JSON object (`}}` as appropriate).
+{chunk_deep_prompt_output_constraint_block()}
 
 For each finding:
 - title: short label (e.g. "Vulnerability found")
@@ -2648,4 +2827,8 @@ For each finding:
 Rules:
 - DO NOT mention any vulnerability type other than {vuln_name}.
 - If no {vuln_name} issues exist, return an empty findings array.
+
+Valid vs invalid typing examples:
+- valid: "exploitation_conditions": "Attacker can reach POST /transfer while authenticated."
+- invalid: "exploitation_conditions": ["User is authenticated", "Endpoint is reachable"]
 """

--- a/oasis/cache.py
+++ b/oasis/cache.py
@@ -5,6 +5,7 @@ import hashlib
 import pickle
 
 from .enums import AnalysisMode, AnalysisType
+from .schemas.analysis import ANALYSIS_SCHEMA_VERSION
 from .tools import create_cache_dir, sanitize_name, logger
 
 class CacheManager:
@@ -66,7 +67,63 @@ class CacheManager:
         self.adaptive_analysis_cache = {}
         
         # Validate cache files and clean expired ones
+        self._cleanup_marker_file = self.cache_dir / f".schema_cleanup_v{ANALYSIS_SCHEMA_VERSION}.done"
+        self._run_schema_cleanup_once()
         self.validate_cache_expiration()
+
+    def _run_schema_cleanup_once(self) -> None:
+        """Run schema cleanup once per cache directory/version."""
+        if self._cleanup_marker_file.exists():
+            return
+        self.cleanup_stale_schema_entries()
+        try:
+            self._cleanup_marker_file.write_text(datetime.now().isoformat(), encoding="utf-8")
+        except OSError as exc:
+            logger.warning(f"Unable to persist schema cleanup marker {self._cleanup_marker_file}: {exc}")
+
+    def cleanup_stale_schema_entries(self) -> None:
+        """Remove stale schema-versioned keys from OASIS cache payloads only."""
+        version_prefix = f"v{ANALYSIS_SCHEMA_VERSION}_"
+        try:
+            cache_dirs = list(self.standard_cache_dir.values()) + list(self.adaptive_cache_dir.values())
+            removed_keys = 0
+            for cache_dir in cache_dirs:
+                if not cache_dir.exists():
+                    continue
+                for cache_file in cache_dir.glob("*.cache"):
+                    try:
+                        with open(cache_file, "rb") as cache_handle:
+                            payload = pickle.load(cache_handle)
+                    except Exception:
+                        # Skip non-OASIS cache payloads or unreadable files.
+                        continue
+
+                    if not isinstance(payload, dict):
+                        continue
+
+                    stale_keys = [
+                        key for key in payload
+                        if isinstance(key, str) and key.startswith("v") and not key.startswith(version_prefix)
+                    ]
+                    if not stale_keys:
+                        continue
+
+                    for stale_key in stale_keys:
+                        payload.pop(stale_key, None)
+                    removed_keys += len(stale_keys)
+
+                    try:
+                        if payload:
+                            with open(cache_file, "wb") as cache_handle:
+                                pickle.dump(payload, cache_handle)
+                        else:
+                            cache_file.unlink()
+                    except OSError as exc:
+                        logger.warning(f"Failed to update stale cache entry {cache_file}: {exc}")
+            if removed_keys:
+                logger.info(f"Removed {removed_keys} stale cache keys from previous schema versions")
+        except Exception as exc:
+            logger.warning(f"Error during stale cache cleanup: {exc}")
     
     def get_cache_path(self, file_path: str, mode: AnalysisMode, 
                      analysis_type: AnalysisType) -> Path:
@@ -272,13 +329,13 @@ class CacheManager:
         # For adaptive analysis (empty chunk)
         if not chunk:
             if file_path:
-                return f"{sanitize_name(file_path)}_{sanitize_name(vuln_name)}"
-            return sanitize_name(vuln_name)
+                return f"v{ANALYSIS_SCHEMA_VERSION}_{sanitize_name(file_path)}_{sanitize_name(vuln_name)}"
+            return f"v{ANALYSIS_SCHEMA_VERSION}_{sanitize_name(vuln_name)}"
             
         # For standard analysis
         chunk_hash = hashlib.md5(chunk.encode()).hexdigest()
         prompt_hash = hashlib.md5(prompt.encode()).hexdigest()
-        return f"{chunk_hash}_{prompt_hash}_{sanitize_name(vuln_name)}"
+        return f"v{ANALYSIS_SCHEMA_VERSION}_{chunk_hash}_{prompt_hash}_{sanitize_name(vuln_name)}"
     
     def clear_scan_cache(self, analysis_type: AnalysisType = None) -> None:
         """

--- a/oasis/config.py
+++ b/oasis/config.py
@@ -841,7 +841,7 @@ EXTRACT_FUNCTIONS = {
 
 # Report configuration
 REPORT = {
-    'OUTPUT_FORMATS': ['pdf', 'html', 'md'],
+    'OUTPUT_FORMATS': ['json', 'pdf', 'html', 'md'],
     'OUTPUT_DIR': 'security_reports',
     'BACKGROUND_COLOR': '#F5F2E9',
     'EXPLAIN_ANALYSIS': """

--- a/oasis/config.py
+++ b/oasis/config.py
@@ -1,7 +1,8 @@
 """
 Configuration constants for OASIS
 """
-from typing import Set
+import logging
+from typing import Any, Dict, List, Optional, Set
 
 # Analysis version (used for cache compatibility)
 # This constant must be incremented manually ONLY when the analysis behavior changes in a way that would make cached results obsolete.
@@ -841,7 +842,9 @@ EXTRACT_FUNCTIONS = {
 
 # Report configuration
 REPORT = {
-    'OUTPUT_FORMATS': ['json', 'pdf', 'html', 'md'],
+    'OUTPUT_FORMATS': ['json', 'sarif', 'pdf', 'html', 'md'],
+    # Dashboard / API: human-readable first; any OUTPUT_FORMATS entry missing here is appended after
+    'DASHBOARD_FORMAT_DISPLAY_ORDER': ['html', 'pdf', 'md', 'json', 'sarif'],
     'OUTPUT_DIR': 'security_reports',
     'BACKGROUND_COLOR': '#F5F2E9',
     'EXPLAIN_ANALYSIS': """
@@ -887,3 +890,25 @@ Code embeddings are advanced representations that convert your code into numeric
 This report provides a high-level overview of security vulnerabilities detected in the codebase.
     """
 }
+
+_cfg_log = logging.getLogger(__name__)
+
+
+def validate_report_dashboard_formats(report_cfg: Optional[Dict[str, Any]] = None) -> List[str]:
+    """
+    Return ``DASHBOARD_FORMAT_DISPLAY_ORDER`` entries that are not in ``OUTPUT_FORMATS``
+    (case-insensitive). Logs a warning when any are found.
+
+    Not run at import time: call from CLI / web entrypoints (see ``OasisScanner._init_arguments``)
+    or from tests that import this function explicitly.
+    """
+    r = report_cfg if report_cfg is not None else REPORT
+    allowed_lower = {str(x).lower() for x in (r.get("OUTPUT_FORMATS") or [])}
+    order = r.get("DASHBOARD_FORMAT_DISPLAY_ORDER") or []
+    bad = [x for x in order if str(x).lower() not in allowed_lower]
+    if bad:
+        _cfg_log.warning(
+            "DASHBOARD_FORMAT_DISPLAY_ORDER contains formats missing from OUTPUT_FORMATS: %s",
+            bad,
+        )
+    return bad

--- a/oasis/embedding.py
+++ b/oasis/embedding.py
@@ -14,7 +14,9 @@ from .config import EXTRACT_FUNCTIONS, SUPPORTED_EXTENSIONS, DEFAULT_ARGS
 
 # Import from other modules
 from .ollama_manager import OllamaManager
+from .schemas.function_extract import FunctionExtractResponse
 from .tools import create_cache_dir, logger, chunk_content, parse_input, sanitize_name, open_file
+from pydantic import ValidationError
 
 class EmbeddingManager:
     def __init__(self, args, ollama_manager: OllamaManager):
@@ -477,7 +479,8 @@ class EmbeddingManager:
             
         return functions
 
-    def extract_functions_with_regex(self, file_path: str, content: str, lang: str) -> Dict[str, str]:
+    @staticmethod
+    def extract_functions_with_regex(file_path: str, content: str, lang: str) -> Dict[str, str]:
         """
         Extract functions using regex patterns based on language
         
@@ -493,7 +496,7 @@ class EmbeddingManager:
         
         try:
             # Get appropriate pattern for the language
-            pattern = self.language_patterns(lang)
+            pattern = EmbeddingManager.language_patterns(lang)
             
             # Find all function declarations
             matches = list(re.finditer(pattern, content, re.DOTALL))
@@ -504,7 +507,7 @@ class EmbeddingManager:
                 func_name = next((g for g in match.groups() if g), f"anonymous_function_{i}")
                 
                 # Determine function end boundary
-                func_end = self._find_function_end(content, func_start, lang)
+                func_end = EmbeddingManager._find_function_end(content, func_start, lang)
                 
                 if func_end > func_start:
                     func_id = f"{file_path}::{func_name}"
@@ -517,7 +520,8 @@ class EmbeddingManager:
             
         return functions
         
-    def _find_function_end(self, content: str, start_pos: int, lang: str) -> int:
+    @staticmethod
+    def _find_function_end(content: str, start_pos: int, lang: str) -> int:
         """
         Find the end position of a function based on language syntax
         
@@ -535,14 +539,15 @@ class EmbeddingManager:
 
         # Delegate to appropriate handler based on language type
         if lang in {'js', 'ts', 'java', 'c', 'cpp', 'cs', 'php', 'go'}:
-            return self._find_brace_function_end(content, start_pos)
+            return EmbeddingManager._find_brace_function_end(content, start_pos)
         elif lang in {'py', 'rb'}:
-            return self._find_indentation_function_end(content, start_pos)
+            return EmbeddingManager._find_indentation_function_end(content, start_pos)
 
         # Fallback for unsupported languages
         return len(content)
         
-    def _find_brace_function_end(self, content: str, start_pos: int) -> int:
+    @staticmethod
+    def _find_brace_function_end(content: str, start_pos: int) -> int:
         """Find end position for languages using braces (C-family, etc.)"""
         brace_level = 0
         in_string = False
@@ -569,7 +574,8 @@ class EmbeddingManager:
                         
         return len(content)
         
-    def _find_indentation_function_end(self, content: str, start_pos: int) -> int:
+    @staticmethod
+    def _find_indentation_function_end(content: str, start_pos: int) -> int:
         """Find end position for languages using indentation (Python, Ruby)"""
         lines = content[start_pos:].split('\n')
         if len(lines) <= 1:
@@ -634,7 +640,8 @@ class EmbeddingManager:
         
         return functions 
 
-    def language_patterns(self, lang: str) -> str:
+    @staticmethod
+    def language_patterns(lang: str) -> str:
         """
         Return the regex pattern for a given language
 
@@ -737,79 +744,78 @@ class EmbeddingManager:
         # Use a small, fast model for this task
         extraction_model = EXTRACT_FUNCTIONS['MODEL']
         if not self.ollama_manager.ensure_model_available(extraction_model):
-            return {}
-        
+            logger.info(f"Function extraction model unavailable for {file_path}; falling back to regex-based extraction")
+            return self.extract_functions_with_regex(file_path, content, extension)
+
         # Make sure we're using a normalized version of the content
         # This ensures the same text is used for LLM analysis and extraction
         normalized_content = content.replace('\r\n', '\n')
-        
+
         # Create prompt
+        schema_hint = json.dumps(FunctionExtractResponse.model_json_schema(), indent=2)
         prompt = f"""
-            Extract all functions and methods from the following {extension} code.
-            {EXTRACT_FUNCTIONS['PROMPT']}
-            Here is the code:
-            ```{extension}
-            {normalized_content}
-            ```
-            """
+Extract all functions and methods from the following {extension} code.
+{EXTRACT_FUNCTIONS['PROMPT']}
+Here is the code:
+```{extension}
+{normalized_content}
+```
+
+Respond with JSON only matching this schema (no markdown fences):
+{schema_hint}
+"""
 
         try:
-            # Generate response with a short context model
-            response = self.ollama_manager.generate(
+            response = self.ollama_manager.chat(
                 model=extraction_model,
-                prompt=prompt,
+                messages=[{"role": "user", "content": prompt}],
+                format=FunctionExtractResponse.model_json_schema(),
+                options={"temperature": 0},
             )
-
-            if not response or not response.response:
+            raw = response.get("message", {}).get("content") if response else None
+            if not raw:
                 logger.warning(f"No valid response from LLM for function extraction in {file_path}")
-                return {}
-
-            # Extract JSON part from response
-            json_match = re.search(r'({[\s\S]*})', response.response)
-            if not json_match:
-                logger.warning(f"No valid JSON found in LLM response for {file_path}")
-                return {}
+                return self.extract_functions_with_regex(file_path, content, extension)
 
             try:
-                result = json.loads(json_match[1])
+                parsed = FunctionExtractResponse.model_validate_json(raw)
+            except ValidationError as e:
+                logger.warning(f"Invalid structured function extract for {file_path}: {e}")
+                return self.extract_functions_with_regex(file_path, content, extension)
 
-                # Extract functions using provided indices
-                functions = {}
-                for func in result.get("functions", []):
-                    name = func.get("name", "anonymous")
-                    start = func.get("start")
-                    end = func.get("end")
-                    # TODO: add body, parameters and return_type
-                    # body = func.get("body")
-                    # parameters = func.get("parameters")
-                    # return_type = func.get("return_type")
+            if not getattr(parsed, "functions", None):
+                logger.info(
+                    f"LLM returned no functions for {file_path}; falling back to regex-based extraction"
+                )
+                return self.extract_functions_with_regex(file_path, content, extension)
 
-                    if start is not None and end is not None and start < end and end <= len(normalized_content):
-                        # Extract from the normalized content that was sent to the LLM
-                        func_content = normalized_content[start:end]
-                        
-                        # Validate that the extracted content looks like a function
-                        # Simple check that the content contains the function name
-                        if name in func_content:
-                            functions[f"{file_path}::{name}"] = func_content
-                        else:
-                            logger.warning(f"Function extraction mismatch for {name} in {file_path}")
-                            # TODO: implement a fallback or more advanced validation
+            functions: Dict[str, str] = {}
+            for func in parsed.functions:
+                name = func.name or "anonymous"
+                start, end = func.start, func.end
+                if start < end <= len(normalized_content):
+                    func_content = normalized_content[start:end]
+                    if name in func_content:
+                        functions[f"{file_path}::{name}"] = func_content
+                    else:
+                        logger.warning(f"Function extraction mismatch for {name} in {file_path}")
+                else:
+                    logger.warning(
+                        f"Invalid function span ({start}, {end}) for {name} in {file_path}; skipping this function"
+                    )
 
+            if functions:
                 return functions
-
-            except json.JSONDecodeError as e:
-                logger.exception(f"Invalid JSON in LLM response for {file_path}: {str(e)}")
-                logger.debug(f"Raw JSON response: {json_match[1][:200]}...")
-                return {}
+            logger.info(
+                f"LLM function extraction for {file_path} yielded no valid functions after validation; "
+                "falling back to regex-based extraction"
+            )
+            return self.extract_functions_with_regex(file_path, content, extension)
 
         except Exception as e:
             logger.exception(f"Error using LLM for function extraction in {file_path}: {str(e)}")
-            # Fallback to regex approach
             logger.info(f"Falling back to regex-based extraction for {file_path}")
             return self.extract_functions_with_regex(file_path, content, extension)
-
-        return {}
 
     def get_vulnerability_embedding(self, vulnerability: Union[str, Dict]) -> List[float]:
         """
@@ -986,40 +992,66 @@ def extract_functions_from_file(file_path: str, content: str, extraction_model: 
 
     # Determine file extension
     extension = file_path.split('.')[-1].lower()
-    
+
     # Make sure we're using a normalized version of the content
     normalized_content = content.replace('\r\n', '\n')
-    
+
     try:
         # Ensure model is available
         if not ollama_manager.ensure_model_available(extraction_model):
-            return {}
-            
-        # Create prompt
+            return _extract_functions_with_regex_fallback(file_path, content, extension)
+
+        schema_hint = json.dumps(FunctionExtractResponse.model_json_schema(), indent=2)
         prompt = f"""
-            Extract all functions and methods from the following {extension} code.
-            {EXTRACT_FUNCTIONS['PROMPT']}
-            Here is the code:
-            ```{extension}
-            {normalized_content}
-            ```
-            """
-            
-        # Generate response
-        response = ollama_manager.generate(
+Extract all functions and methods from the following {extension} code.
+{EXTRACT_FUNCTIONS['PROMPT']}
+Here is the code:
+```{extension}
+{normalized_content}
+```
+
+Respond with JSON only matching this schema (no markdown fences):
+{schema_hint}
+"""
+
+        response = ollama_manager.chat(
             model=extraction_model,
-            prompt=prompt,
+            messages=[{"role": "user", "content": prompt}],
+            format=FunctionExtractResponse.model_json_schema(),
+            options={"temperature": 0},
         )
-        
-        if not response or not response.response:
+        raw = response.get("message", {}).get("content") if response else None
+        if not raw:
             logger.warning(f"No valid response from LLM for function extraction in {file_path}")
             return {}
-            
-        # Process response and extract functions
-        # ... (code from extract_functions_with_llm that parses the JSON response)
-        
+
+        parsed = FunctionExtractResponse.model_validate_json(raw)
+        out: Dict[str, str] = {}
+        for func in parsed.functions:
+            start, end = func.start, func.end
+            if start < end <= len(normalized_content):
+                func_content = normalized_content[start:end]
+                name = func.name or "anonymous"
+                if name in func_content:
+                    out[f"{file_path}::{name}"] = func_content
+        return out
+
+    except ValidationError as e:
+        logger.warning(f"Structured function extract failed for {file_path}: {e}")
+        return _extract_functions_with_regex_fallback(file_path, content, extension)
     except Exception as e:
         logger.exception(f"Error extracting functions from {file_path}: {str(e)}")
-        # Fallback to regex approach if needed
-        
-    return {}
+        return _extract_functions_with_regex_fallback(file_path, content, extension)
+
+
+def _extract_functions_with_regex_fallback(file_path: str, content: str, extension: str) -> Dict[str, str]:
+    """
+    Lightweight shared fallback for function extraction.
+
+    Reuses EmbeddingManager regex extraction behavior.
+    """
+    try:
+        return EmbeddingManager.extract_functions_with_regex(file_path, content, extension)
+    except Exception as e:
+        logger.exception(f"Regex fallback function extraction failed for {file_path}: {str(e)}")
+        return {f"{file_path}::__file_blob__": content} if content else {}

--- a/oasis/export/__init__.py
+++ b/oasis/export/__init__.py
@@ -1,0 +1,14 @@
+"""
+Report export helpers.
+
+Import submodules directly (e.g. ``from oasis.export.vulnerability import write_vulnerability_artifacts``)
+so environments without WeasyPrint can still use ``oasis.export.filenames`` / ``oasis.export.sarif``.
+
+Multi-artifact writers return :class:`~oasis.export.result_types.ArtifactWriteStatusMap`
+(see ``oasis.export.result_types``).
+"""
+
+from .filenames import artifact_filename
+from .result_types import ArtifactWriteStatusMap
+
+__all__ = ["artifact_filename", "ArtifactWriteStatusMap"]

--- a/oasis/export/filenames.py
+++ b/oasis/export/filenames.py
@@ -1,0 +1,24 @@
+"""Filename helpers for report artifacts (single place for format-specific naming)."""
+
+
+def artifact_filename(stem: str, fmt: str) -> str:
+    """
+    Build the on-disk basename for a report format directory.
+
+    Most formats use ``{stem}.{fmt}``. SARIF uses the ``.sarif`` extension while
+    living under a ``sarif/`` directory (same pattern as ``fmt == "sarif"``).
+    """
+    return f"{stem}.sarif" if fmt == "sarif" else f"{stem}.{fmt}"
+
+
+def report_dir_glob_for_format(fmt: str) -> str:
+    """
+    Glob pattern for listing report files under a per-format subdirectory.
+
+    ``fmt`` is normalized to lower case so patterns match files from :func:`artifact_filename`
+    regardless of config casing. Matches basenames produced by ``artifact_filename`` (no ``*.*``).
+    """
+    key = str(fmt or "").strip().lower()
+    if key == "json":
+        return "*.json"
+    return "*.sarif" if key == "sarif" else f"*.{key}"

--- a/oasis/export/markdown_outputs.py
+++ b/oasis/export/markdown_outputs.py
@@ -1,0 +1,33 @@
+"""Persist HTML/PDF produced from markdown-based reports (audit, executive summary)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict
+
+from .result_types import ArtifactWriteStatusMap
+from .writers import write_html_pdf_from_rendered
+
+
+def write_rendered_markdown_formats(
+    output_files: Dict[str, Path],
+    rendered_html: str,
+    *,
+    logger: logging.Logger,
+    context_label: str,
+) -> ArtifactWriteStatusMap:
+    """
+    Write HTML and PDF keys present in ``output_files`` from fully rendered HTML.
+
+    Returns an ``ArtifactWriteStatusMap`` (see ``oasis.export.result_types``):
+    shallow copy of ``output_files`` merged with :func:`write_html_pdf_from_rendered`.
+    ``output_files`` is not mutated in place.
+    """
+    merged: ArtifactWriteStatusMap = dict(output_files)
+    subset = {k: v for k, v in output_files.items() if k in ("html", "pdf")}
+    if not subset:
+        return merged
+    written = write_html_pdf_from_rendered(subset, rendered_html, logger=logger, context_label=context_label)
+    merged |= written
+    return merged

--- a/oasis/export/result_types.py
+++ b/oasis/export/result_types.py
@@ -1,0 +1,20 @@
+"""
+Shared typing aliases for multi-artifact report exports.
+
+**Artifact write status map** (``ArtifactWriteStatusMap``):
+
+- Returned by :func:`~oasis.export.vulnerability.write_vulnerability_artifacts`,
+  :func:`~oasis.export.writers.write_html_pdf_from_rendered`, and
+  :func:`~oasis.export.markdown_outputs.write_rendered_markdown_formats`.
+- Keys are format names (e.g. ``"json"``, ``"html"``, ``"pdf"``) as in the input path dict.
+- Values are ``pathlib.Path`` when that artifact was written successfully, or ``None`` when
+  the write failed or was skipped after failure. The input dict is not mutated; callers
+  must inspect the return value to detect failures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+ArtifactWriteStatusMap = Dict[str, Optional[Path]]

--- a/oasis/export/sarif.py
+++ b/oasis/export/sarif.py
@@ -55,10 +55,10 @@ def vulnerability_document_to_sarif(
     """
     Map a ``VulnerabilityReportDocument`` to a SARIF 2.1.0 ``sarifLog`` object.
 
-    Omits ``startLine`` / ``endLine`` when the analysis schema does not provide them;
-    ``region.snippet`` carries ``vulnerable_code`` when present. When line/column
-    metadata exists on findings in the future, extend this builder to emit richer
-    ``region`` objects and/or multiple ``tool.driver.rules`` for finer de-duplication.
+    Fills ``region.startLine`` / ``region.endLine`` from finding-level
+    ``snippet_start_line`` / ``snippet_end_line`` when present (resolved from
+    ``vulnerable_code`` inside the analyzed chunk); otherwise falls back to the
+    chunk span. ``region.snippet`` carries ``vulnerable_code`` when present.
     """
     rule_id = _slug_rule_id(doc.vulnerability_name)
     vuln_meta: Dict[str, Any] = doc.vulnerability if isinstance(doc.vulnerability, dict) else {}
@@ -89,8 +89,17 @@ def vulnerability_document_to_sarif(
                 physical: Dict[str, Any] = {
                     "artifactLocation": {"uri": uri},
                 }
+                region: Dict[str, Any] = {}
                 if snippet_text := (finding.vulnerable_code or "").strip():
-                    physical["region"] = {"snippet": {"text": snippet_text}}
+                    region["snippet"] = {"text": snippet_text}
+                if finding.snippet_start_line is not None and finding.snippet_end_line is not None:
+                    region["startLine"] = finding.snippet_start_line
+                    region["endLine"] = finding.snippet_end_line
+                elif chunk.start_line is not None and chunk.end_line is not None:
+                    region["startLine"] = chunk.start_line
+                    region["endLine"] = chunk.end_line
+                if region:
+                    physical["region"] = region
 
                 result: Dict[str, Any] = {
                     "ruleId": rule_id,

--- a/oasis/export/sarif.py
+++ b/oasis/export/sarif.py
@@ -1,0 +1,130 @@
+"""Build SARIF 2.1.0 logs from canonical vulnerability report documents."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from ..schemas.analysis import VulnerabilityFinding, VulnerabilityReportDocument
+
+SARIF_SCHEMA = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+OASIS_INFORMATION_URI = "https://github.com/psyray/oasis"
+
+
+def _slug_rule_id(vulnerability_name: str) -> str:
+    slug = vulnerability_name.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-") or "oasis-finding"
+
+
+def _severity_to_level(severity: str) -> str:
+    """Map a severity string to a SARIF ``result.level`` value (case-insensitive)."""
+    normalized = (severity or "").strip().lower()
+    mapping = {
+        "critical": "error",
+        "high": "error",
+        "medium": "warning",
+        "low": "note",
+    }
+    return mapping.get(normalized, "warning")
+
+
+def _artifact_uri(file_path: str) -> str:
+    """Use path as stored in the report (portable relative paths when the scanner used them)."""
+    return file_path.replace("\\", "/")
+
+
+def _finding_message(finding: VulnerabilityFinding) -> str:
+    parts: List[str] = []
+    if finding.title:
+        parts.append(finding.title.strip())
+    if finding.explanation:
+        parts.append(finding.explanation.strip())
+    if finding.impact:
+        parts.append(f"Impact: {finding.impact.strip()}")
+    if finding.remediation:
+        parts.append(f"Remediation: {finding.remediation.strip()}")
+    return "\n\n".join(p for p in parts if p)
+
+
+def vulnerability_document_to_sarif(
+    doc: VulnerabilityReportDocument,
+    *,
+    tool_version: str,
+) -> Dict[str, Any]:
+    """
+    Map a ``VulnerabilityReportDocument`` to a SARIF 2.1.0 ``sarifLog`` object.
+
+    Omits ``startLine`` / ``endLine`` when the analysis schema does not provide them;
+    ``region.snippet`` carries ``vulnerable_code`` when present. When line/column
+    metadata exists on findings in the future, extend this builder to emit richer
+    ``region`` objects and/or multiple ``tool.driver.rules`` for finer de-duplication.
+    """
+    rule_id = _slug_rule_id(doc.vulnerability_name)
+    vuln_meta: Dict[str, Any] = doc.vulnerability if isinstance(doc.vulnerability, dict) else {}
+
+    short_desc = str(vuln_meta.get("description") or doc.vulnerability_name)[:512]
+    full_parts: List[str] = [f"**{doc.vulnerability_name}**", "", short_desc]
+    if vuln_meta.get("impact"):
+        full_parts.extend(["", f"**Impact (type metadata)**\n{vuln_meta['impact']}"])
+    if vuln_meta.get("mitigation"):
+        full_parts.extend(["", f"**Mitigation (type metadata)**\n{vuln_meta['mitigation']}"])
+    full_description = "\n".join(full_parts)
+
+    rule = {
+        "id": rule_id,
+        "name": doc.vulnerability_name,
+        "shortDescription": {"text": short_desc},
+        "fullDescription": {"text": full_description},
+        "helpUri": OASIS_INFORMATION_URI,
+    }
+
+    results: List[Dict[str, Any]] = []
+    for file_entry in doc.files:
+        if file_entry.error:
+            continue
+        uri = _artifact_uri(file_entry.file_path)
+        for chunk_index, chunk in enumerate(file_entry.chunk_analyses):
+            for finding_index, finding in enumerate(chunk.findings):
+                physical: Dict[str, Any] = {
+                    "artifactLocation": {"uri": uri},
+                }
+                if snippet_text := (finding.vulnerable_code or "").strip():
+                    physical["region"] = {"snippet": {"text": snippet_text}}
+
+                result: Dict[str, Any] = {
+                    "ruleId": rule_id,
+                    "level": _severity_to_level(finding.severity),
+                    "message": {"text": _finding_message(finding)},
+                    "locations": [{"physicalLocation": physical}],
+                    "properties": {
+                        "oasisModel": doc.model_name,
+                        "oasisFileSimilarity": file_entry.similarity_score,
+                        "oasisChunkIndex": chunk_index,
+                        "oasisFindingIndex": finding_index,
+                    },
+                }
+                results.append(result)
+
+    run: Dict[str, Any] = {
+        "tool": {
+            "driver": {
+                "name": "OASIS",
+                "version": tool_version,
+                "informationUri": OASIS_INFORMATION_URI,
+                "rules": [rule],
+            }
+        },
+        "results": results,
+        "properties": {
+            "oasisReportTitle": doc.title,
+            "oasisGeneratedAt": doc.generated_at,
+            "oasisVulnerabilityName": doc.vulnerability_name,
+        },
+    }
+
+    return {
+        "$schema": SARIF_SCHEMA,
+        "version": "2.1.0",
+        "runs": [run],
+    }

--- a/oasis/export/vulnerability.py
+++ b/oasis/export/vulnerability.py
@@ -1,0 +1,104 @@
+"""Write vulnerability report artifacts to disk for all configured formats.
+
+Each write is wrapped with exception logging. PDF generation uses ``write_pdf_from_html``,
+which logs failures and returns ``False`` without raising when WeasyPrint fails.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Dict
+
+from ..schemas.analysis import VulnerabilityReportDocument
+from . import sarif as sarif_builder
+from .result_types import ArtifactWriteStatusMap
+from .writers import write_json_document, write_pdf_from_html, write_sarif_json, write_utf8_text
+
+
+def _write_artifact_safe(
+    logger: logging.Logger,
+    safe_name_for_logs: str,
+    label: str,
+    write_fn: Callable[[], object],
+) -> bool:
+    """
+    Run a disk write with consistent logging.
+
+    Returns False when ``write_fn`` raises or returns False (e.g. PDF conversion).
+    """
+    artifact_label = f"{safe_name_for_logs}:{label}"
+    try:
+        outcome = write_fn()
+        return outcome is not False
+    except Exception:
+        logger.exception("Failed to write %s vulnerability artifact", artifact_label)
+        return False
+
+
+def write_vulnerability_artifacts(
+    output_files: Dict[str, Path],
+    doc: VulnerabilityReportDocument,
+    *,
+    rendered_html: str,
+    md_body: str,
+    logger: logging.Logger,
+    safe_name_for_logs: str,
+    tool_version: str,
+) -> ArtifactWriteStatusMap:
+    """
+    Persist JSON, SARIF, HTML, PDF, and MD for keys present in ``output_files``.
+
+    Returns an ``ArtifactWriteStatusMap`` (see ``oasis.export.result_types``).
+    """
+    result: ArtifactWriteStatusMap = dict(output_files)
+
+    if "json" in output_files and not _write_artifact_safe(
+                logger,
+                safe_name_for_logs,
+                "json",
+                lambda: write_json_document(output_files["json"], doc),
+            ):
+        result["json"] = None
+
+    if "sarif" in output_files:
+        sarif_payload = sarif_builder.vulnerability_document_to_sarif(doc, tool_version=tool_version)
+        if not _write_artifact_safe(
+            logger,
+            safe_name_for_logs,
+            "sarif",
+            lambda: write_sarif_json(output_files["sarif"], sarif_payload),
+        ):
+            result["sarif"] = None
+
+    if "html" in output_files and not _write_artifact_safe(
+                logger,
+                safe_name_for_logs,
+                "html",
+                lambda: write_utf8_text(output_files["html"], rendered_html),
+            ):
+        result["html"] = None
+
+    if "pdf" in output_files and not _write_artifact_safe(
+                logger,
+                safe_name_for_logs,
+                "pdf",
+                lambda: write_pdf_from_html(
+                    output_files["pdf"],
+                    rendered_html,
+                    logger=logger,
+                    context_label=safe_name_for_logs,
+                ),
+            ):
+        result["pdf"] = None
+
+    if "md" in output_files and not _write_artifact_safe(
+                logger,
+                safe_name_for_logs,
+                "md",
+                lambda: write_utf8_text(output_files["md"], md_body),
+            ):
+        result["md"] = None
+
+    return result

--- a/oasis/export/writers.py
+++ b/oasis/export/writers.py
@@ -1,0 +1,113 @@
+"""Low-level disk writers for report exports (no Jinja orchestration)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from weasyprint import HTML
+
+from ..schemas.analysis import VulnerabilityReportDocument
+from .result_types import ArtifactWriteStatusMap
+
+
+def ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_utf8_text(path: Path, text: str) -> None:
+    ensure_parent_dir(path)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_markdown_lines(path: Path, lines: List[str], logger: logging.Logger) -> None:
+    try:
+        ensure_parent_dir(path)
+        path.write_text("\n".join(lines), encoding="utf-8")
+    except Exception as e:
+        logger.exception("Error writing markdown file: %s", e)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Full error:", exc_info=True)
+
+
+def write_json_document(path: Path, doc: VulnerabilityReportDocument) -> None:
+    ensure_parent_dir(path)
+    path.write_text(doc.model_dump_json(indent=2), encoding="utf-8")
+
+
+def write_sarif_json(path: Path, payload: dict) -> None:
+    ensure_parent_dir(path)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def write_pdf_from_html(
+    path: Path,
+    html_str: str,
+    *,
+    logger: logging.Logger,
+    context_label: str,
+) -> bool:
+    """
+    Write PDF from full HTML string. Returns True on success, False on failure.
+    """
+    ensure_parent_dir(path)
+    try:
+        HTML(string=html_str, media_type="print").write_pdf(path)
+        return True
+    except Exception as e:
+        logger.exception("PDF conversion failed for %s: %s: %s", context_label, e.__class__.__name__, e)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("HTML (first 500 chars): %s", html_str[:500])
+        return False
+
+
+def write_html_pdf_from_rendered(
+    output_files: Dict[str, Path],
+    rendered_html: str,
+    *,
+    logger: logging.Logger,
+    context_label: str,
+) -> ArtifactWriteStatusMap:
+    """
+    Persist rendered HTML and optional PDF for paths present in ``output_files``.
+
+    Returns an ``ArtifactWriteStatusMap`` (see ``oasis.export.result_types``).
+
+    **Contract:** ``output_files`` is not modified. The return value is a shallow copy
+    that may replace ``"html"`` and/or ``"pdf"`` values with ``None`` when conversion
+    fails (PDF failure sets ``result["pdf"]`` to ``None``; a caught outer exception returns
+    only ``html`` / ``pdf`` keys that were present in ``output_files``, each set to ``None``).
+    On success, returned paths match the input paths for html/pdf. Callers must use the
+    returned dict to observe failure, not the original ``output_files`` dict.
+    """
+    result: Dict[str, Path | None] = dict(output_files)
+    try:
+        if "html" in output_files:
+            write_utf8_text(output_files["html"], rendered_html)
+        if "pdf" in output_files:
+            ok = write_pdf_from_html(
+                output_files["pdf"],
+                rendered_html,
+                logger=logger,
+                context_label=context_label,
+            )
+            if not ok:
+                result["pdf"] = None
+        return result
+    except Exception as e:
+        return handle_html_pdf_conversion_error(
+            logger, context_label, e, output_files
+        )
+
+def handle_html_pdf_conversion_error(logger, context_label, e, output_files):
+    logger.exception("Error converting %s to other formats: %s: %s", context_label, e.__class__.__name__, e)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Full error:", exc_info=True)
+    out: Dict[str, Path | None] = {}
+    if "html" in output_files:
+        out["html"] = None
+    if "pdf" in output_files:
+        out["pdf"] = None
+    return out

--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -8,7 +8,7 @@ from typing import Union
 
 
 # Import from configuration
-from .config import MODEL_EMOJIS, REPORT, DEFAULT_ARGS
+from .config import MODEL_EMOJIS, REPORT, DEFAULT_ARGS, validate_report_dashboard_formats
 
 # Import from other modules
 from .tools import generate_timestamp, setup_logging, logger, display_logo, get_vulnerability_mapping
@@ -46,6 +46,58 @@ class OasisScanner:
             return False
         raise argparse.ArgumentTypeError("Expected 'yes' or 'no'")
 
+    @staticmethod
+    def _parse_output_formats_list(raw: str) -> list:
+        """
+        Normalize comma-separated ``--output-format`` values to canonical ``REPORT['OUTPUT_FORMATS']`` strings.
+
+        Tokens are stripped and matched case-insensitively. Unknown tokens raise ValueError.
+        """
+        allowed = REPORT["OUTPUT_FORMATS"]
+        canon = {}
+        for f in allowed:
+            key = str(f).lower()
+            if key not in canon:
+                canon[key] = f
+        tokens = [t.strip() for t in raw.split(",") if t.strip()]
+        if not tokens:
+            return list(allowed)
+        out = []
+        seen: set[str] = set()
+        unknown = []
+        for t in tokens:
+            key = t.lower()
+            if key not in canon:
+                unknown.append(t)
+                continue
+            c = canon[key]
+            if c in seen:
+                continue
+            seen.add(c)
+            out.append(c)
+        if unknown:
+            allowed_s = ", ".join(allowed)
+            unk_s = ", ".join(unknown)
+            raise ValueError(
+                f"Unknown output format(s): {unk_s}. Use 'all' or one or more of: {allowed_s}"
+            )
+        return out
+
+    @staticmethod
+    def _output_format_cli_type(value: str) -> list:
+        """
+        argparse ``type`` for ``--output-format``: returns a canonical list of format strings.
+        """
+        if not isinstance(value, str):
+            raise argparse.ArgumentTypeError("--output-format must be a string")
+        s = value.strip()
+        if s.lower() == "all":
+            return list(REPORT["OUTPUT_FORMATS"])
+        try:
+            return OasisScanner._parse_output_formats_list(s)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(str(exc)) from exc
+
     def setup_argument_parser(self):
         """
         Configure and return argument parser
@@ -68,8 +120,17 @@ class OasisScanner:
         io_group = parser.add_argument_group('Input/Output Options')
         io_group.add_argument('-i', '--input', dest='input_path', type=str, 
                             help='Path to file, directory, or .txt file containing paths to analyze')
-        io_group.add_argument('-of', '--output-format', type=str, default=DEFAULT_ARGS['OUTPUT_FORMAT'],
-                            help=f'Output format [json, pdf, html, md] (default: {DEFAULT_ARGS["OUTPUT_FORMAT"]})')
+        io_group.add_argument(
+            '-of',
+            '--output-format',
+            type=OasisScanner._output_format_cli_type,
+            default=DEFAULT_ARGS['OUTPUT_FORMAT'],
+            help=(
+                f'Output format(s): comma-separated or "all" for '
+                f'{", ".join(REPORT["OUTPUT_FORMATS"])} (default: {DEFAULT_ARGS["OUTPUT_FORMAT"]}). '
+                f'Tokens are case-insensitive; spaces around commas are ignored.'
+            ),
+        )
         io_group.add_argument('-x', '--extensions', type=str,
                             help='Comma-separated list of file extensions to analyze (e.g., "py,js,java")')
         
@@ -347,11 +408,19 @@ class OasisScanner:
         # Now setup full logging with appropriate paths
         self._setup_logging()
 
-        # Process output format
-        if self.args.output_format == 'all':
-            self.args.output_format = REPORT['OUTPUT_FORMATS']
+        validate_report_dashboard_formats()
+
+        # Process output format (argparse usually supplies list via type=; support injected str)
+        of_raw = self.args.output_format
+        if isinstance(of_raw, list):
+            self.args.output_format = of_raw
+        elif isinstance(of_raw, str):
+            try:
+                self.args.output_format = OasisScanner._output_format_cli_type(of_raw)
+            except argparse.ArgumentTypeError as exc:
+                return self._handle_argument_errors(str(exc))
         else:
-            self.args.output_format = self.args.output_format.split(',')
+            return self._handle_argument_errors("Invalid --output-format / -of value")
 
         display_logo()
         return True

--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -69,7 +69,7 @@ class OasisScanner:
         io_group.add_argument('-i', '--input', dest='input_path', type=str, 
                             help='Path to file, directory, or .txt file containing paths to analyze')
         io_group.add_argument('-of', '--output-format', type=str, default=DEFAULT_ARGS['OUTPUT_FORMAT'],
-                            help=f'Output format [pdf, html, md] (default: {DEFAULT_ARGS["OUTPUT_FORMAT"]})')
+                            help=f'Output format [json, pdf, html, md] (default: {DEFAULT_ARGS["OUTPUT_FORMAT"]})')
         io_group.add_argument('-x', '--extensions', type=str,
                             help='Comma-separated list of file extensions to analyze (e.g., "py,js,java")')
         
@@ -484,6 +484,8 @@ class OasisScanner:
         # Create the report directories for all main models
         self.report.models = main_models
         self.report.create_report_directories(self.args.input_path, models=main_models)
+        self.args.run_id = getattr(self.report, "output_dir_name", None)
+        self._configure_run_error_logging()
 
         # Run analysis with all main models
         result = self.run_analysis_mode(main_models, scan_model, vuln_mapping)
@@ -515,13 +517,21 @@ class OasisScanner:
         Args:
             None
         """
-        if self.args.silent:
-            logs_dir = Path(self.args.input_path).resolve().parent / REPORT['OUTPUT_DIR'] / "logs" if self.args.input_path else Path(REPORT['OUTPUT_DIR']) / "logs"
-            logs_dir.mkdir(parents=True, exist_ok=True)
-            log_file = logs_dir / f"oasis_errors_{generate_timestamp(for_file=True)}.log"
-        else:
-            log_file = None
-            
+        # Base logging initialization (console behavior, levels).
+        # Run-specific error file logging is configured once report output_dir is known.
+        setup_logging(debug=self.args.debug, silent=self.args.silent, error_log_file=None)
+
+    def _configure_run_error_logging(self):
+        """
+        Configure run-specific error log file in security_reports/<run>/logs.
+        """
+        if not hasattr(self, "report") or not getattr(self.report, "output_dir", None):
+            return
+
+        logs_dir = self.report.output_dir / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        run_id = getattr(self.report, "output_dir_name", generate_timestamp(for_file=True))
+        log_file = logs_dir / f"oasis_errors_{run_id}.log"
         setup_logging(debug=self.args.debug, silent=self.args.silent, error_log_file=log_file)
 
     def _handle_argument_errors(self, arg0):

--- a/oasis/report.py
+++ b/oasis/report.py
@@ -8,12 +8,15 @@ import markdown
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 from jinja2 import Environment, FileSystemLoader
-from weasyprint import HTML
 
 # Import from configuration
 from .config import REPORT
 
 # Import from other modules
+from .export import artifact_filename
+from .export.vulnerability import write_vulnerability_artifacts
+from .export.markdown_outputs import write_rendered_markdown_formats
+from .export.writers import write_markdown_lines
 from .schemas.analysis import (
     ChunkDeepAnalysis,
     FileReportEntry,
@@ -21,6 +24,10 @@ from .schemas.analysis import (
     build_dashboard_stats,
 )
 from .tools import extract_clean_path, logger, sanitize_name, generate_timestamp
+
+# Package metadata (process constant; avoid lazy imports in hot paths)
+from . import __version__ as oasis_version
+
 
 class Report:
     """
@@ -237,34 +244,28 @@ class Report:
         logger.debug("--------------------------------")
         logger.debug(f"Generating Vulnerability report for {', '.join(self.output_format)}, please wait...")
 
-        if "json" in output_files:
-            self.ensure_directory(output_files["json"].parent)
-            output_files["json"].write_text(doc.model_dump_json(indent=2), encoding="utf-8")
-
         inner_html = self._render_vulnerability_inner_html(doc)
         rendered_html = self.render_template(inner_html)
-
-        if "html" in output_files:
-            self.ensure_directory(output_files["html"].parent)
-            with open(output_files["html"], "w", encoding="utf-8") as f:
-                f.write(rendered_html)
-
-        if "pdf" in output_files:
-            self.ensure_directory(output_files["pdf"].parent)
-            try:
-                HTML(string=rendered_html, media_type="print").write_pdf(output_files["pdf"])
-            except Exception as e:
-                logger.exception(f"PDF conversion failed for {safe_name}: {e.__class__.__name__}: {e}")
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"HTML (first 500 chars): {rendered_html[:500]}")
-
+        md_body = ""
         if "md" in output_files:
-            self.ensure_directory(output_files["md"].parent)
             md_body = self._render_vulnerability_markdown_export(doc)
-            with open(output_files["md"], "w", encoding="utf-8") as f:
-                f.write(md_body)
 
-        return output_files
+        written = write_vulnerability_artifacts(
+            output_files,
+            doc,
+            rendered_html=rendered_html,
+            md_body=md_body,
+            logger=logger,
+            safe_name_for_logs=safe_name,
+            tool_version=oasis_version,
+        )
+        if missing := [k for k, p in written.items() if p is None]:
+            logger.warning(
+                "Some vulnerability report artifacts failed for %s (formats: %s)",
+                safe_name,
+                ", ".join(missing),
+            )
+        return {k: p for k, p in written.items() if p is not None}
     
     def _generate_and_save_report(self, output_files, report_content, report_type: str = None):
         """
@@ -279,10 +280,10 @@ class Report:
         logger.debug(f"Generating {report_type} report for {', '.join(self.output_format)}, please wait...")
 
         # Write markdown
-        self.write_markdown(output_files['md'], report_content)
-        
+        write_markdown_lines(output_files["md"], report_content, logger)
+
         # Convert to PDF and HTML
-        self.convert_to_all_formats(output_files['md'])
+        self.convert_to_all_formats(output_files["md"])
 
     def report_generated(self, report_type: str = None, report_structure: bool = False):
         """
@@ -494,27 +495,6 @@ class Report:
         
         return output_files
     
-    def write_markdown(self, file_path: Path, content: List[str]) -> None:
-        """
-        Write content to markdown file
-        
-        Args:
-            file_path: Path to output file
-            content: List of content lines
-        """
-        try:
-            # Ensure parent directory exists
-            self.ensure_directory(file_path.parent)
-            
-            # Write content to file
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.write('\n'.join(content))
-                
-        except Exception as e:
-            logger.exception(f"Error writing markdown file: {str(e)}")
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Full error:", exc_info=True)
-    
     def convert_to_all_formats(self, markdown_file: Path) -> Dict[str, Path]:
         """
         Convert markdown file to PDF and HTML
@@ -529,36 +509,23 @@ class Report:
         output_files = self.filter_output_files(markdown_file.stem)
 
         try:
-            # Read and convert markdown to HTML
             html_content = self.read_and_convert_markdown(markdown_file)
-
-            # Render HTML using the template
             rendered_html = self.render_template(html_content)
-
-            # Write HTML file
-            with open(output_files['html'], 'w', encoding='utf-8') as f:
-                f.write(rendered_html)
-
-            # Convert to PDF
-            try:
-                HTML(string=rendered_html, media_type='print').write_pdf(output_files['pdf'])
-            except Exception as e:
-                logger.exception(f"PDF conversion failed for {markdown_file.name}: {e.__class__.__name__}: {str(e)}")
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(f"HTML content causing PDF conversion failure (first 500 chars): {rendered_html[:500]}")
-                output_files['pdf'] = None
-            
-            return output_files
-            
+            return write_rendered_markdown_formats(
+                output_files,
+                rendered_html,
+                logger=logger,
+                context_label=markdown_file.name,
+            )
         except Exception as e:
             logger.exception(f"Error converting {markdown_file.name} to other formats: {e.__class__.__name__}: {str(e)}")
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug("Full error:", exc_info=True)
 
             return {
-                'md': markdown_file,
-                'pdf': None,
-                'html': None
+                "md": markdown_file,
+                "pdf": None,
+                "html": None,
             }
 
     def read_and_convert_markdown(self, markdown_file: Path) -> str:
@@ -572,8 +539,7 @@ class Report:
             HTML content
         """
         # Read markdown content
-        with open(markdown_file, 'r', encoding='utf-8') as f:
-            markdown_content = f.read()
+        markdown_content = markdown_file.read_text(encoding="utf-8")
 
         # Parse HTML with Beautiful Soup and fix any issues
         soup = BeautifulSoup(markdown.markdown(markdown_content, extensions=['tables', 'fenced_code', 'codehilite']), 'html.parser')
@@ -601,8 +567,7 @@ class Report:
             logo_path = images_dir / 'oasis-logo.jpg'
             
             # Encode the logo in base64
-            with open(logo_path, "rb") as image_file:
-                encoded_string = base64.b64encode(image_file.read()).decode('utf-8')
+            encoded_string = base64.b64encode(logo_path.read_bytes()).decode("utf-8")
             
             # Create a data URL for the image
             logo_data_url = f"data:image/jpeg;base64,{encoded_string}"
@@ -707,8 +672,9 @@ class Report:
         """
         model_name = sanitize_name(self.current_model)
         return {
-            fmt: self.report_dirs[model_name][fmt] / f"{safe_name}.{fmt}"
-            for fmt in self.output_format if fmt in self.report_dirs[model_name]
+            fmt: self.report_dirs[model_name][fmt] / artifact_filename(safe_name, fmt)
+            for fmt in self.output_format
+            if fmt in self.report_dirs[model_name]
         }
 
     def get_output_directory(self, input_path: str | Path, base_reports_dir: Path) -> Path:

--- a/oasis/report.py
+++ b/oasis/report.py
@@ -1,18 +1,25 @@
 import base64
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
 from bs4 import BeautifulSoup
 import markdown
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
-from weasyprint import HTML
-from pathlib import Path
-from typing import List, Dict, Optional
-import logging
 from jinja2 import Environment, FileSystemLoader
+from weasyprint import HTML
 
 # Import from configuration
 from .config import REPORT
 
 # Import from other modules
+from .schemas.analysis import (
+    ChunkDeepAnalysis,
+    FileReportEntry,
+    VulnerabilityReportDocument,
+    build_dashboard_stats,
+)
 from .tools import extract_clean_path, logger, sanitize_name, generate_timestamp
 
 class Report:
@@ -117,73 +124,146 @@ class Report:
             
         return header
     
-    def generate_vulnerability_report(self, vulnerability: Dict, results: List[Dict], 
-                                     model_name: str) -> Dict[str, Path]:
-        """
-        Generate a report for a specific vulnerability type
-        
-        Args:
-            vulnerability: Vulnerability (Dict - VULNERABILITY_MAPPING element)
-            results: Analysis results
-            model_name: Model name used for analysis
-            
-        Returns:
-            Dictionary of report file paths
-        """
-        # Clean vulnerability name for filenames
-        vuln_name = vulnerability['name']
-        safe_name = vuln_name.lower().replace(' ', '_')
-        
-        # Set output file paths and filter by output format in one step
-        output_files = self.filter_output_files(safe_name)
-
-        # Create report content
-        report = self.create_header(f"{vuln_name} Security Analysis", model_name)
-        
-        # Add summary section
-        report.extend([
-            "\n## Summary",
-            f"\nAnalyzed {len(results)} files for {vuln_name} vulnerabilities.",
-            "\n| File | Similarity Score |",
-            "|------|-----------------|"
-        ])
-        
-        # Add each file with its score
+    def _results_to_file_entries(self, results: List[Dict]) -> List[FileReportEntry]:
+        analysis_notes_max_len = 2000
+        truncation_suffix = " [truncated]"
+        entries: List[FileReportEntry] = []
         for result in results:
-            score = result.get('similarity_score', 0.0)
-            file_path = result.get('file_path', 'Unknown file')
-            report.append(f"| `{file_path}` | {score:.3f} |")
-        
-        # Add detailed analysis section
-        report.append('\n<div class="page-break"></div>\n')
-        report.append("\n## Detailed Analysis\n")
-        
-        for i, result in enumerate(results):
-            file_path = result.get('file_path', 'Unknown file')
-            score = result.get('similarity_score', 0.0)
-            
-            # Add page break between files except for the first one
-            if i > 0:
-                report.append('\n<div class="page-break"></div>\n')
-            
-            # Check if analysis key exists
-            if 'analysis' in result:
-                # Normalize the heading levels in the analysis
-                analysis = result['analysis']
-            elif 'error' in result:
-                analysis = f"**Error during analysis:** {result['error']}"
-            else:
-                analysis = "No detailed analysis available"
-            
-            report.extend([
-                f"### File: {file_path}",
-                f"Similarity Score: {score:.3f}",
-                "\n#### Analysis Results\n",
-                analysis
-            ])
-        
-        self._generate_and_save_report(output_files, report, report_type='Vulnerability')
-        
+            chunk_models: List[ChunkDeepAnalysis] = []
+            for raw in result.get("structured_chunks") or []:
+                try:
+                    if isinstance(raw, dict):
+                        raw_copy = dict(raw)
+                        notes = raw_copy.get("notes")
+                        truncated = bool(raw_copy.get("truncated", False))
+                        if isinstance(notes, str) and len(notes) > analysis_notes_max_len:
+                            raw_copy["notes"] = (
+                                notes[: analysis_notes_max_len - len(truncation_suffix)]
+                                + truncation_suffix
+                            )
+                            truncated = True
+                        raw_copy["truncated"] = truncated
+                        chunk_models.append(ChunkDeepAnalysis.model_validate(raw_copy))
+                    else:
+                        chunk_models.append(ChunkDeepAnalysis.model_validate(raw))
+                except Exception:
+                    raw_str = str(raw)
+                    truncated = False
+                    if len(raw_str) > analysis_notes_max_len:
+                        raw_str = (
+                            raw_str[: analysis_notes_max_len - len(truncation_suffix)]
+                            + truncation_suffix
+                        )
+                        truncated = True
+                    chunk_models.append(
+                        ChunkDeepAnalysis(findings=[], notes=raw_str, truncated=truncated)
+                    )
+            if not chunk_models and result.get("analysis"):
+                analysis_str = str(result["analysis"])
+                truncated = False
+                if len(analysis_str) > analysis_notes_max_len:
+                    analysis_str = (
+                        analysis_str[: analysis_notes_max_len - len(truncation_suffix)]
+                        + truncation_suffix
+                    )
+                    truncated = True
+                chunk_models.append(
+                    ChunkDeepAnalysis(findings=[], notes=analysis_str, truncated=truncated)
+                )
+            entries.append(
+                FileReportEntry(
+                    file_path=result.get("file_path", "Unknown file"),
+                    similarity_score=float(result.get("similarity_score", 0.0)),
+                    chunk_analyses=chunk_models,
+                    error=result.get("error"),
+                )
+            )
+        return entries
+
+    def _build_vulnerability_document(
+        self, vulnerability: Dict, results: List[Dict], model_name: str
+    ) -> VulnerabilityReportDocument:
+        vuln_name = vulnerability["name"]
+        file_entries = self._results_to_file_entries(results)
+        stats = self._compute_document_stats(file_entries)
+        return VulnerabilityReportDocument(
+            title=f"{vuln_name} Security Analysis",
+            generated_at=generate_timestamp(),
+            model_name=model_name,
+            vulnerability_name=vuln_name,
+            vulnerability=dict(vulnerability),
+            files=file_entries,
+            stats=stats,
+        )
+
+    @staticmethod
+    def _compute_document_stats(file_entries: List[FileReportEntry]):
+        """Single source of truth for dashboard statistics aggregation."""
+        return build_dashboard_stats(file_entries)
+
+    def _render_vulnerability_inner_html(self, doc: VulnerabilityReportDocument) -> str:
+        template = self.template_env.get_template("reports/vulnerability_from_json.html.j2")
+        return template.render(document=doc.model_dump(mode="json"))
+
+    def _render_vulnerability_markdown_export(self, doc: VulnerabilityReportDocument) -> str:
+        template = self.template_env.get_template("reports/vulnerability_export.md.j2")
+        return template.render(document=doc.model_dump(mode="json"))
+
+    def render_report_html_from_json_payload(self, payload: Dict) -> str:
+        """
+        Render report HTML directly from canonical JSON payload.
+        """
+        report_type = payload.get("report_type")
+        if report_type != "vulnerability":
+            raise ValueError(f"Unsupported canonical report type: {report_type}")
+
+        doc = VulnerabilityReportDocument.model_validate(payload)
+        # Keep JSON payload and template rendering aligned on one stats helper.
+        doc.stats = self._compute_document_stats(doc.files)
+        inner_html = self._render_vulnerability_inner_html(doc)
+        return self.render_template(inner_html)
+
+    def generate_vulnerability_report(
+        self, vulnerability: Dict, results: List[Dict], model_name: str
+    ) -> Dict[str, Path]:
+        """
+        Generate vulnerability report: canonical JSON plus Jinja-derived HTML/PDF and optional MD export.
+        """
+        vuln_name = vulnerability["name"]
+        safe_name = vuln_name.lower().replace(" ", "_")
+        output_files = self.filter_output_files(safe_name)
+        doc = self._build_vulnerability_document(vulnerability, results, model_name)
+
+        logger.debug("--------------------------------")
+        logger.debug(f"Generating Vulnerability report for {', '.join(self.output_format)}, please wait...")
+
+        if "json" in output_files:
+            self.ensure_directory(output_files["json"].parent)
+            output_files["json"].write_text(doc.model_dump_json(indent=2), encoding="utf-8")
+
+        inner_html = self._render_vulnerability_inner_html(doc)
+        rendered_html = self.render_template(inner_html)
+
+        if "html" in output_files:
+            self.ensure_directory(output_files["html"].parent)
+            with open(output_files["html"], "w", encoding="utf-8") as f:
+                f.write(rendered_html)
+
+        if "pdf" in output_files:
+            self.ensure_directory(output_files["pdf"].parent)
+            try:
+                HTML(string=rendered_html, media_type="print").write_pdf(output_files["pdf"])
+            except Exception as e:
+                logger.exception(f"PDF conversion failed for {safe_name}: {e.__class__.__name__}: {e}")
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"HTML (first 500 chars): {rendered_html[:500]}")
+
+        if "md" in output_files:
+            self.ensure_directory(output_files["md"].parent)
+            md_body = self._render_vulnerability_markdown_export(doc)
+            with open(output_files["md"], "w", encoding="utf-8") as f:
+                f.write(md_body)
+
         return output_files
     
     def _generate_and_save_report(self, output_files, report_content, report_type: str = None):

--- a/oasis/schemas/__init__.py
+++ b/oasis/schemas/__init__.py
@@ -1,0 +1,23 @@
+"""Structured analysis and report schemas for OASIS."""
+
+from .analysis import (
+    ANALYSIS_SCHEMA_VERSION,
+    ChunkDeepAnalysis,
+    DashboardStats,
+    FileReportEntry,
+    MediumRiskAnalysis,
+    ScanVerdict,
+    VulnerabilityFinding,
+    VulnerabilityReportDocument,
+)
+
+__all__ = [
+    "ANALYSIS_SCHEMA_VERSION",
+    "ChunkDeepAnalysis",
+    "DashboardStats",
+    "FileReportEntry",
+    "MediumRiskAnalysis",
+    "ScanVerdict",
+    "VulnerabilityFinding",
+    "VulnerabilityReportDocument",
+]

--- a/oasis/schemas/analysis.py
+++ b/oasis/schemas/analysis.py
@@ -1,0 +1,175 @@
+"""
+Pydantic models for Ollama structured outputs and canonical vulnerability reports.
+
+All user-facing strings in instances should follow English prompts from the analyzer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+# Bump when changing chunk or report shapes (cache invalidation).
+ANALYSIS_SCHEMA_VERSION = 1
+
+
+class ScanVerdict(BaseModel):
+    """Structured response for lightweight scan (one chunk)."""
+
+    verdict: Literal["SUSPICIOUS", "CLEAN", "ERROR"]
+
+
+class MediumRiskAnalysis(BaseModel):
+    """Adaptive pipeline medium-depth structured response."""
+
+    risk_score: int = Field(ge=0, le=100, description="Risk score 0-100")
+    analysis: str = Field(default="", description="Brief analysis text")
+    validation_error: bool = Field(default=False, description="True when structured validation failed")
+
+
+class VulnerabilityFinding(BaseModel):
+    """Single finding aligned with deep analysis prompt intent."""
+
+    title: str = Field(default="Vulnerability found", description="Short section title")
+    vulnerable_code: str = Field(default="", description="Quoted vulnerable snippet")
+    explanation: str = Field(default="", description="Why this is vulnerable")
+    severity: Literal["Critical", "High", "Medium", "Low"] = Field(
+        default="Medium", description="Severity for this finding"
+    )
+    impact: str = Field(default="", description="Potential impact")
+    entry_point: str = Field(default="", description="Route, endpoint, or function entry")
+    execution_path_diagram: str = Field(
+        default="",
+        description="ASCII flowchart for execution path (markdown-friendly text allowed)",
+    )
+    http_methods: List[str] = Field(default_factory=list)
+    manipulable_parameters: List[str] = Field(default_factory=list)
+    exploitation_steps: List[str] = Field(default_factory=list)
+    example_payloads: List[str] = Field(default_factory=list)
+    exploitation_conditions: str = Field(default="", description="Dependencies for exploitation")
+    remediation: str = Field(default="", description="Remediation guidance")
+    secure_code_example: str = Field(default="", description="Secure code example if any")
+
+
+class ChunkDeepAnalysis(BaseModel):
+    """Structured deep analysis for one code chunk."""
+
+    findings: List[VulnerabilityFinding] = Field(default_factory=list)
+    notes: Optional[str] = Field(default=None, description="Optional analyst notes")
+    validation_error: bool = Field(default=False, description="True when structured validation failed")
+    potential_vulnerabilities: bool = Field(
+        default=False,
+        description="True when findings are unknown due to parse/validation failures",
+    )
+    truncated: bool = Field(default=False, description="True when notes were truncated for size limits")
+
+
+class FileReportEntry(BaseModel):
+    """One file row inside a vulnerability report document."""
+
+    file_path: str
+    similarity_score: float
+    chunk_analyses: List[ChunkDeepAnalysis] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class DashboardStats(BaseModel):
+    """Precomputed stats for the web dashboard (no markdown parsing)."""
+
+    files_analyzed: int = 0
+    high_risk: int = 0
+    medium_risk: int = 0
+    low_risk: int = 0
+    critical_risk: int = 0
+    total_findings: int = 0
+    potential_findings: int = 0
+
+
+class VulnerabilityReportDocument(BaseModel):
+    """Canonical on-disk JSON for one vulnerability-type report."""
+
+    schema_version: int = Field(default=ANALYSIS_SCHEMA_VERSION)
+    report_type: Literal["vulnerability"] = "vulnerability"
+    title: str
+    generated_at: str
+    model_name: str
+    vulnerability_name: str
+    vulnerability: Dict[str, Any] = Field(default_factory=dict)
+    files: List[FileReportEntry] = Field(default_factory=list)
+    stats: DashboardStats = Field(default_factory=DashboardStats)
+
+
+ScanVerdict.model_rebuild()
+VulnerabilityFinding.model_rebuild()
+ChunkDeepAnalysis.model_rebuild()
+FileReportEntry.model_rebuild()
+VulnerabilityReportDocument.model_rebuild()
+
+
+def build_dashboard_stats(files: List[FileReportEntry]) -> DashboardStats:
+    """Aggregate severities from structured chunk analyses."""
+    stats = DashboardStats()
+    for entry in files:
+        if entry.error:
+            continue
+        stats.files_analyzed += 1
+        for chunk in entry.chunk_analyses:
+            if chunk.potential_vulnerabilities:
+                stats.potential_findings += 1
+            for f in chunk.findings:
+                stats.total_findings += 1
+                sev = f.severity
+                if sev == "Critical":
+                    stats.critical_risk += 1
+                elif sev == "High":
+                    stats.high_risk += 1
+                elif sev == "Medium":
+                    stats.medium_risk += 1
+                elif sev == "Low":
+                    stats.low_risk += 1
+    return stats
+
+
+def chunk_analysis_to_markdown(chunk: ChunkDeepAnalysis, chunk_index: int) -> str:
+    """Render chunk structured analysis as markdown for adaptive combined reports."""
+    parts: List[str] = []
+    if not chunk.findings:
+        parts.append(
+            f"#### Chunk {chunk_index + 1}\n\nNo vulnerabilities identified in structured output.\n"
+        )
+        if chunk.notes:
+            parts.append(f"\n**Notes**: {chunk.notes}\n")
+        return "\n".join(parts)
+    for i, finding in enumerate(chunk.findings):
+        parts.extend(
+            (
+                f"#### Finding {i + 1} (chunk {chunk_index + 1}): {finding.title}\n",
+                f"- **Severity**: {finding.severity}\n",
+            )
+        )
+        if finding.vulnerable_code:
+            parts.append("```\n" + finding.vulnerable_code.strip() + "\n```\n")
+        parts.append(f"\n{finding.explanation}\n")
+        if finding.impact:
+            parts.append(f"\n**Impact**: {finding.impact}\n")
+        if finding.entry_point:
+            parts.append(f"\n**Entry point**: {finding.entry_point}\n")
+        if finding.execution_path_diagram:
+            parts.append("\n## Execution Path\n\n```\n" + finding.execution_path_diagram.strip() + "\n```\n")
+        if finding.http_methods:
+            parts.append("\n**HTTP methods**: " + ", ".join(finding.http_methods) + "\n")
+        if finding.manipulable_parameters:
+            parts.append("\n**Parameters**: " + ", ".join(finding.manipulable_parameters) + "\n")
+        if finding.exploitation_steps:
+            parts.append("\n**Exploitation steps**:\n" + "\n".join(f"- {s}" for s in finding.exploitation_steps) + "\n")
+        if finding.example_payloads:
+            parts.append("\n**Example payloads**:\n" + "\n".join(f"- `{p}`" for p in finding.example_payloads) + "\n")
+        if finding.exploitation_conditions:
+            parts.append(f"\n**Conditions**: {finding.exploitation_conditions}\n")
+        if finding.remediation:
+            parts.append(f"\n**Remediation**: {finding.remediation}\n")
+        if finding.secure_code_example:
+            parts.append("\n**Secure example**:\n```\n" + finding.secure_code_example.strip() + "\n```\n")
+        parts.append('\n<div class="page-break"></div>\n')
+    return "\n".join(parts)

--- a/oasis/schemas/analysis.py
+++ b/oasis/schemas/analysis.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 # Bump when changing chunk or report shapes (cache invalidation).
-ANALYSIS_SCHEMA_VERSION = 1
+ANALYSIS_SCHEMA_VERSION = 3
 
 
 class ScanVerdict(BaseModel):
@@ -50,12 +50,28 @@ class VulnerabilityFinding(BaseModel):
     exploitation_conditions: str = Field(default="", description="Dependencies for exploitation")
     remediation: str = Field(default="", description="Remediation guidance")
     secure_code_example: str = Field(default="", description="Secure code example if any")
+    snippet_start_line: Optional[int] = Field(
+        default=None,
+        description="1-based first line of vulnerable_code in the file when resolved in the chunk (tooling)",
+    )
+    snippet_end_line: Optional[int] = Field(
+        default=None,
+        description="1-based last line of vulnerable_code in the file when resolved in the chunk (tooling)",
+    )
 
 
 class ChunkDeepAnalysis(BaseModel):
     """Structured deep analysis for one code chunk."""
 
     findings: List[VulnerabilityFinding] = Field(default_factory=list)
+    start_line: Optional[int] = Field(
+        default=None,
+        description="1-based first line of this chunk in the source file (tooling; not from LLM)",
+    )
+    end_line: Optional[int] = Field(
+        default=None,
+        description="1-based last line of this chunk in the source file (tooling; not from LLM)",
+    )
     notes: Optional[str] = Field(default=None, description="Optional analyst notes")
     validation_error: bool = Field(default=False, description="True when structured validation failed")
     potential_vulnerabilities: bool = Field(
@@ -134,9 +150,12 @@ def build_dashboard_stats(files: List[FileReportEntry]) -> DashboardStats:
 def chunk_analysis_to_markdown(chunk: ChunkDeepAnalysis, chunk_index: int) -> str:
     """Render chunk structured analysis as markdown for adaptive combined reports."""
     parts: List[str] = []
+    line_hint = ""
+    if chunk.start_line is not None and chunk.end_line is not None:
+        line_hint = f" _(source lines {chunk.start_line}-{chunk.end_line})_"
     if not chunk.findings:
         parts.append(
-            f"#### Chunk {chunk_index + 1}\n\nNo vulnerabilities identified in structured output.\n"
+            f"#### Chunk {chunk_index + 1}{line_hint}\n\nNo vulnerabilities identified in structured output.\n"
         )
         if chunk.notes:
             parts.append(f"\n**Notes**: {chunk.notes}\n")
@@ -144,7 +163,7 @@ def chunk_analysis_to_markdown(chunk: ChunkDeepAnalysis, chunk_index: int) -> st
     for i, finding in enumerate(chunk.findings):
         parts.extend(
             (
-                f"#### Finding {i + 1} (chunk {chunk_index + 1}): {finding.title}\n",
+                f"#### Finding {i + 1} (chunk {chunk_index + 1}){line_hint}: {finding.title}\n",
                 f"- **Severity**: {finding.severity}\n",
             )
         )

--- a/oasis/schemas/function_extract.py
+++ b/oasis/schemas/function_extract.py
@@ -1,0 +1,15 @@
+"""Structured output for LLM-based function extraction."""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class ExtractedFunctionSpan(BaseModel):
+    name: str = Field(default="anonymous")
+    start: int = Field(ge=0)
+    end: int = Field(ge=0)
+
+
+class FunctionExtractResponse(BaseModel):
+    functions: List[ExtractedFunctionSpan] = Field(default_factory=list)

--- a/oasis/snippet_lines.py
+++ b/oasis/snippet_lines.py
@@ -1,0 +1,50 @@
+"""
+Resolve 1-based inclusive line ranges for vulnerable snippets inside a chunk.
+
+Used after LLM analysis so SARIF and JSON can point at the snippet when it is
+locatable in the analyzed segment (heuristic; not AST-based).
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+
+def substring_line_span_1based(haystack: str, needle: str) -> Optional[Tuple[int, int]]:
+    """
+    Return 1-based inclusive (start_line, end_line) for the first occurrence of
+    ``needle`` in ``haystack``. Lines follow newline boundaries in ``haystack``.
+    """
+    n = (needle or "").strip()
+    if not n:
+        return None
+
+    def span_for_char_range(start_char: int, end_char_inclusive: int) -> Tuple[int, int]:
+        start_ln = haystack.count("\n", 0, start_char) + 1
+        end_ln = haystack.count("\n", 0, end_char_inclusive + 1) + 1
+        return (start_ln, end_ln)
+
+    idx = haystack.find(n)
+    if idx >= 0:
+        return span_for_char_range(idx, idx + len(n) - 1)
+
+    first_line = n.split("\n", 1)[0].strip()
+    if len(first_line) >= 8:
+        k = haystack.find(first_line)
+        if k >= 0:
+            return span_for_char_range(k, k + len(first_line) - 1)
+
+    return None
+
+
+def absolute_snippet_lines_in_file(
+    chunk_text: str,
+    chunk_start_line: int,
+    vulnerable_code: str,
+) -> Optional[Tuple[int, int]]:
+    """Map a snippet inside ``chunk_text`` to absolute 1-based file lines."""
+    rel = substring_line_span_1based(chunk_text, vulnerable_code)
+    if rel is None:
+        return None
+    rel_s, rel_e = rel
+    return (chunk_start_line + rel_s - 1, chunk_start_line + rel_e - 1)

--- a/oasis/static/css/dashboard.css
+++ b/oasis/static/css/dashboard.css
@@ -1152,6 +1152,21 @@ body {
     margin-bottom: 10px;
 }
 
+#report-modal-content h4 {
+    color: var(--dark-blue);
+    font-size: 16px;
+    margin-top: 14px;
+    margin-bottom: 8px;
+}
+
+#report-modal-content h5 {
+    color: var(--dark-blue);
+    font-size: 14px;
+    margin-top: 12px;
+    margin-bottom: 6px;
+    font-weight: 600;
+}
+
 #report-modal-content p {
     margin: 12px 0;
 }
@@ -1170,6 +1185,22 @@ body {
     border-radius: 5px;
     overflow-x: auto;
     border-left: 3px solid var(--turquoise);
+}
+
+.json-report-preview {
+    max-height: 400px;
+    overflow: auto;
+}
+
+.json-preview {
+    margin: 0;
+    white-space: pre;
+}
+
+.json-preview-notice {
+    font-size: 0.9em;
+    color: #666;
+    margin-bottom: 0.5rem;
 }
 
 #report-modal-content a {
@@ -1228,7 +1259,24 @@ body {
     margin: 20px 0;
 }
 
-.html-content-container,
+#report-modal-content .report-file-block {
+    background-color: var(--white);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--turquoise);
+    border-radius: 8px;
+    padding: 12px 14px;
+    margin: 14px 0 18px 0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.html-content-container {
+    width: 100%;
+    height: calc(100vh - 200px);
+    border: none;
+    border-radius: 0;
+    background: transparent;
+}
+
 .pdf-container {
     width: 100%;
     height: calc(100vh - 200px);

--- a/oasis/static/js/dashboard-app.js
+++ b/oasis/static/js/dashboard-app.js
@@ -104,6 +104,7 @@ const DashboardApp = {
         return new Promise((resolve, reject) => {
             // Define modules to load in order
             const modules = [
+                'bootstrap.js',
                 'utils.js',
                 'filters.js',
                 'views.js',

--- a/oasis/static/js/dashboard-app.js
+++ b/oasis/static/js/dashboard-app.js
@@ -129,6 +129,9 @@ const DashboardApp = {
             // Load scripts sequentially
             const loadNextScript = (index) => {
                 if (index >= modules.length) {
+                    if (typeof DashboardApp.initFormatHelpers === 'function') {
+                        DashboardApp.initFormatHelpers();
+                    }
                     resolve();
                     return;
                 }

--- a/oasis/static/js/dashboard/api.js
+++ b/oasis/static/js/dashboard/api.js
@@ -50,14 +50,16 @@ DashboardApp.fetchReports = function() {
             
             // Process and store the reports
             DashboardApp.reportData = DashboardApp.groupReportsByModelAndVuln(reports);
+            DashboardApp.buildReportFormatsByPathMap(DashboardApp.reportData);
             
             // Render the reports in the current view
             DashboardApp.renderCurrentView();
         })
         .catch(error => {
             console.error('Error fetching reports:', error);
+            const errorMessage = DashboardApp._errorMessage(error);
             document.getElementById('reports-container').innerHTML = 
-                `<div class="error-message">Error fetching reports: ${error.message}</div>`;
+                `<div class="error-message">Error fetching reports: ${DashboardApp._escapeHtml(errorMessage)}</div>`;
         });
 };
 
@@ -99,8 +101,9 @@ DashboardApp.fetchStats = function(forceRefresh = false) {
         })
         .catch(error => {
             console.error('Error fetching stats:', error);
+            const errorMessage = DashboardApp._errorMessage(error);
             document.getElementById('stats-container').innerHTML = 
-                `<div class="error-message">Error fetching stats: ${error.message}</div>`;
+                `<div class="error-message">Error fetching stats: ${DashboardApp._escapeHtml(errorMessage)}</div>`;
         });
 };
 
@@ -114,12 +117,13 @@ DashboardApp.refreshDashboard = function() {
     // Fetch fresh data
     Promise.all([
         fetch('/api/stats?force=1').then(response => response.json()),
-        fetch('/api/reports').then(response => response.json())
+        fetch('/api/reports?force=1&md_dates_only=1').then(response => response.json())
     ])
     .then(([statsData, reportsData]) => {
         // Update the state
         this.stats = statsData;
         this.reportData = this.groupReportsByModelAndVuln(reportsData);
+        this.buildReportFormatsByPathMap(this.reportData);
         
         // Render the updated data
         this.renderStats();

--- a/oasis/static/js/dashboard/bootstrap.js
+++ b/oasis/static/js/dashboard/bootstrap.js
@@ -1,4 +1,13 @@
 // Bootstrap helpers shared across dashboard modules.
+// Download-format iconography lives here (view/theme layer), not in utils.js.
+DashboardApp.FORMAT_DOWNLOAD_LABELS = {
+    json: '📋',
+    sarif: '🔶',
+    md: '📝',
+    html: '📃',
+    pdf: '📄'
+};
+
 DashboardApp._escapeHtml = function(text) {
     if (text === null || text === undefined) {
         return '';

--- a/oasis/static/js/dashboard/bootstrap.js
+++ b/oasis/static/js/dashboard/bootstrap.js
@@ -1,0 +1,34 @@
+// Bootstrap helpers shared across dashboard modules.
+DashboardApp._escapeHtml = function(text) {
+    if (text === null || text === undefined) {
+        return '';
+    }
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+};
+
+DashboardApp._escapeJsSingleQuote = function(text) {
+    if (text === null || text === undefined) {
+        return '';
+    }
+    return String(text).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+};
+
+DashboardApp._errorMessage = function(error) {
+    if (error && error.message) {
+        return String(error.message);
+    }
+    return String(error || 'Unknown error');
+};
+
+DashboardApp._buildOpenReportOnclick = function(path, format) {
+    const escapedPath = DashboardApp._escapeJsSingleQuote(path);
+    const escapedFormat = DashboardApp._escapeJsSingleQuote(format);
+    return `openReport('${escapedPath}', '${escapedFormat}')`;
+};
+
+DashboardApp.debug("Bootstrap module loaded");

--- a/oasis/static/js/dashboard/interactions.js
+++ b/oasis/static/js/dashboard/interactions.js
@@ -99,6 +99,8 @@ DashboardApp.filterDatesByModel = function(modelElement) {
 
 DashboardApp.updateDatesForModel = function(card, modelName, vulnType) {
     DashboardApp.debug("Updating dates for model:", modelName, "vulnerability:", vulnType);
+    const h = DashboardApp._escapeHtml;
+    const jsq = DashboardApp._escapeJsSingleQuote;
     
     // Show loading in the dates container
     const datesContainer = card.querySelector('.dates-list');
@@ -136,8 +138,8 @@ DashboardApp.updateDatesForModel = function(card, modelName, vulnType) {
                             
                             datesHtml += `
                                 <span class="date-tag clickable" 
-                                    onclick="DashboardApp.openReport('${path}', '${format}')" 
-                                    data-model="${modelName}">
+                                    onclick="DashboardApp.openReport('${jsq(path)}', '${jsq(format)}')" 
+                                    data-model="${h(modelName)}">
                                     <div class="date-main">${formattedDate}</div>
                                     <div class="date-time">${formattedTime}</div>
                                 </span>
@@ -149,8 +151,8 @@ DashboardApp.updateDatesForModel = function(card, modelName, vulnType) {
                             
                             datesHtml += `
                                 <span class="date-tag clickable" 
-                                    onclick="DashboardApp.openReport('${path}', '${format}')" 
-                                    data-model="${modelName}">
+                                    onclick="DashboardApp.openReport('${jsq(path)}', '${jsq(format)}')" 
+                                    data-model="${h(modelName)}">
                                     <div class="date-main">No date</div>
                                 </span>
                             `;
@@ -165,13 +167,15 @@ DashboardApp.updateDatesForModel = function(card, modelName, vulnType) {
         .catch(error => {
             console.error('Error fetching dates:', error);
             if (datesContainer) {
-                datesContainer.innerHTML = `<span class="error-message">Error loading dates: ${error.message}</span>`;
+                datesContainer.innerHTML = `<span class="error-message">Error loading dates: ${h(error.message)}</span>`;
             }
         });
 };
 
 DashboardApp.updateDatesForVulnerability = function(vulnElement, vulnType) {
     DashboardApp.debug("Updating dates for vulnerability:", vulnType);
+    const h = DashboardApp._escapeHtml;
+    const jsq = DashboardApp._escapeJsSingleQuote;
     
     // Get the containing section
     const section = vulnElement.closest('.tree-section');
@@ -213,9 +217,9 @@ DashboardApp.updateDatesForVulnerability = function(vulnElement, vulnType) {
                             
                             datesHtml += `
                                 <span class="date-tag clickable" 
-                                    onclick="DashboardApp.openReport('${path}', '${format}')" 
-                                    data-model="${modelName}">
-                                    <div class="date-label">${modelName}:</div>
+                                    onclick="DashboardApp.openReport('${jsq(path)}', '${jsq(format)}')" 
+                                    data-model="${h(modelName)}">
+                                    <div class="date-label">${h(modelName)}:</div>
                                     <div class="date-main">${formattedDate}</div>
                                     <div class="date-time">${formattedTime}</div>
                                 </span>
@@ -228,9 +232,9 @@ DashboardApp.updateDatesForVulnerability = function(vulnElement, vulnType) {
                             
                             datesHtml += `
                                 <span class="date-tag clickable" 
-                                    onclick="DashboardApp.openReport('${path}', '${format}')" 
-                                    data-model="${modelName}">
-                                    <div class="date-label">${modelName}:</div>
+                                    onclick="DashboardApp.openReport('${jsq(path)}', '${jsq(format)}')" 
+                                    data-model="${h(modelName)}">
+                                    <div class="date-label">${h(modelName)}:</div>
                                     <div class="date-main">No date</div>
                                 </span>
                             `;
@@ -245,7 +249,7 @@ DashboardApp.updateDatesForVulnerability = function(vulnElement, vulnType) {
         .catch(error => {
             console.error('Error fetching dates:', error);
             if (datesContainer) {
-                datesContainer.innerHTML = `<span class="error-message">Error loading dates: ${error.message}</span>`;
+                datesContainer.innerHTML = `<span class="error-message">Error loading dates: ${h(error.message)}</span>`;
             }
         });
 };

--- a/oasis/static/js/dashboard/modal.js
+++ b/oasis/static/js/dashboard/modal.js
@@ -1,3 +1,124 @@
+DashboardApp.renderJsonReportPreview = function(doc) {
+    const lines = [];
+    const files = Array.isArray(doc.files) ? doc.files : [];
+    const stats = doc.stats || {};
+
+    lines.push(`# ${doc.title || 'Security Analysis Report'}`);
+    lines.push('');
+    if (doc.generated_at) {
+        lines.push(`Date: ${doc.generated_at}`);
+    }
+    if (doc.model_name) {
+        lines.push(`Model: ${doc.model_name}`);
+    }
+    if (doc.vulnerability_name) {
+        lines.push(`Vulnerability: ${doc.vulnerability_name}`);
+    }
+
+    lines.push('');
+    lines.push('## Summary');
+    lines.push('');
+    lines.push(`Analyzed ${files.length} file(s).`);
+    lines.push('');
+    lines.push(`- Total findings: ${stats.total_findings || 0}`);
+    lines.push(`- Critical: ${stats.critical_risk || 0}`);
+    lines.push(`- High: ${stats.high_risk || 0}`);
+    lines.push(`- Medium: ${stats.medium_risk || 0}`);
+    lines.push(`- Low: ${stats.low_risk || 0}`);
+    lines.push('');
+
+    lines.push('| File | Similarity |');
+    lines.push('|------|------------|');
+    files.forEach(fileEntry => {
+        const score = typeof fileEntry.similarity_score === 'number'
+            ? fileEntry.similarity_score.toFixed(3)
+            : '0.000';
+        lines.push(`| \`${fileEntry.file_path || 'unknown'}\` | ${score} |`);
+    });
+
+    lines.push('');
+    lines.push('## Detailed Analysis');
+    lines.push('');
+
+    files.forEach(fileEntry => {
+        lines.push(`### ${fileEntry.file_path || 'unknown file'}`);
+        if (typeof fileEntry.similarity_score === 'number') {
+            lines.push(`Similarity score: ${fileEntry.similarity_score.toFixed(3)}`);
+        }
+        lines.push('');
+
+        if (fileEntry.error) {
+            lines.push(`**Error:** ${fileEntry.error}`);
+            lines.push('');
+        }
+
+        const chunkAnalyses = Array.isArray(fileEntry.chunk_analyses) ? fileEntry.chunk_analyses : [];
+        chunkAnalyses.forEach(chunk => {
+            if (chunk.notes && (!chunk.findings || chunk.findings.length === 0)) {
+                lines.push(`_Notes_: ${chunk.notes}`);
+                lines.push('');
+            }
+
+            const findings = Array.isArray(chunk.findings) ? chunk.findings : [];
+            findings.forEach((finding, idx) => {
+                lines.push(`#### Finding ${idx + 1}: ${finding.title || 'Vulnerability found'} (${finding.severity || 'Unknown'})`);
+                lines.push('');
+                if (finding.vulnerable_code) {
+                    lines.push('```');
+                    lines.push(finding.vulnerable_code);
+                    lines.push('```');
+                    lines.push('');
+                }
+                if (finding.explanation) {
+                    lines.push(finding.explanation);
+                    lines.push('');
+                }
+                if (finding.impact) {
+                    lines.push(`**Impact:** ${finding.impact}`);
+                }
+                if (finding.remediation) {
+                    lines.push(`**Remediation:** ${finding.remediation}`);
+                }
+                lines.push('');
+            });
+        });
+    });
+
+    const markdownPreview = lines.join('\n');
+    return (
+        '<div class="json-report-preview">' +
+        DashboardApp.convertMarkdownToHtml(markdownPreview) +
+        '</div>'
+    );
+};
+
+DashboardApp.getAvailableFormatsForPath = function(path, currentFormat) {
+    const byPath = DashboardApp.reportFormatsByPath || {};
+    if (byPath[path] && Array.isArray(byPath[path].formats)) {
+        return byPath[path].formats;
+    }
+
+    const report = (DashboardApp.reportData || []).find(item => {
+        if (item.path === path) {
+            return true;
+        }
+        const alternativeFormats = item.alternative_formats || {};
+        return Object.values(alternativeFormats).some(candidatePath => candidatePath === path);
+    });
+    if (!report) {
+        return currentFormat ? [currentFormat] : [];
+    }
+
+    const available = new Set();
+    const alternativeFormats = report.alternative_formats || {};
+    Object.keys(alternativeFormats).forEach(fmt => available.add(fmt.toLowerCase()));
+    if (report.format) {
+        available.add(String(report.format).toLowerCase());
+    }
+
+    return Array.from(available);
+};
+
 DashboardApp.ensureModalStyles = function() {
     // Check if styles already exist
     if (document.getElementById('modal-dynamic-styles')) {
@@ -19,6 +140,7 @@ DashboardApp.ensureModalStyles = function() {
 
 DashboardApp.openReport = function(path, format) {
     DashboardApp.debug("Opening report:", path, format);
+    const jsq = DashboardApp._escapeJsSingleQuote;
     if (!path) {
         console.error("No path provided for report");
         return;
@@ -67,29 +189,91 @@ DashboardApp.openReport = function(path, format) {
         .join(' ');
     
     modalTitle.textContent = vulnType;
-    
-    // Fetch report content based on format
-    if (format === 'md') {
-        // Use the API endpoint for markdown content
-        fetch(`/api/report-content/${encodeURIComponent(path)}`)
-            .then(response => {
+
+    if (format === 'json') {
+        // Prefer canonical JSON rendered via server-side Jinja HTML.
+        const markdownPath = path
+            .replace('/json/', '/md/')
+            .replace(/\.json$/i, '.md');
+
+        fetch(`/api/report-html?path=${encodeURIComponent(path)}`)
+            .then(async (response) => {
+                const data = await response.json();
                 if (!response.ok) {
-                    throw new Error(`HTTP error: ${response.status}`);
+                    throw new Error(data.error || `HTTP error: ${response.status}`);
                 }
-                return response.json();
+                return data;
             })
-            .then(data => {
+            .then((data) => {
                 if (data.content) {
-                    // The content is already HTML, just insert it
+                    const htmlContainer = document.createElement('div');
+                    htmlContainer.className = 'html-content-container';
+                    htmlContainer.innerHTML = data.content;
+
+                    const elementsToRemove = htmlContainer.querySelectorAll('html, head, body, script, style, link');
+                    elementsToRemove.forEach(el => {
+                        if (el.tagName.toLowerCase() === 'body') {
+                            const bodyContent = el.innerHTML;
+                            el.parentNode.innerHTML = bodyContent;
+                        } else {
+                            el.remove();
+                        }
+                    });
+
+                    modalContent.innerHTML = '';
+                    modalContent.appendChild(htmlContainer);
+                } else {
+                    modalContent.innerHTML = '<div class="error-message">Unable to load report content.</div>';
+                }
+                DashboardApp.hideLoading('report-modal-content');
+            })
+            .catch((error) => {
+                console.error('Error fetching canonical HTML preview for JSON path:', error);
+                // Legacy fallback: render markdown companion when canonical JSON HTML preview fails.
+                fetch(`/api/report-content/${encodeURIComponent(markdownPath)}?allow_canonical_json_preview=1`)
+                    .then(async (response) => {
+                        const data = await response.json();
+                        if (!response.ok) {
+                            throw new Error(data.error || `HTTP error: ${response.status}`);
+                        }
+                        return data;
+                    })
+                    .then((data) => {
+                        if (data.content) {
+                            modalContent.innerHTML = data.content;
+                        } else {
+                            modalContent.innerHTML = '<div class="error-message">Unable to load report content.</div>';
+                        }
+                        DashboardApp.hideLoading('report-modal-content');
+                    })
+                    .catch((markdownError) => {
+                        console.error('Error fetching markdown fallback for JSON path:', markdownError);
+                        const errorMessage = DashboardApp._errorMessage(markdownError);
+                        modalContent.innerHTML = `<div class="error-message">Error loading report content: ${DashboardApp._escapeHtml(errorMessage)}</div>`;
+                        DashboardApp.hideLoading('report-modal-content');
+                    });
+            });
+    } else if (format === 'md') {
+        fetch(`/api/report-content/${encodeURIComponent(path)}`)
+            .then(async (response) => {
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(data.error || `HTTP error: ${response.status}`);
+                }
+                return data;
+            })
+            .then((data) => {
+                if (data.content) {
                     modalContent.innerHTML = data.content;
                 } else {
                     modalContent.innerHTML = '<div class="error-message">Unable to load report content.</div>';
                 }
                 DashboardApp.hideLoading('report-modal-content');
             })
-            .catch(error => {
+            .catch((error) => {
                 console.error('Error fetching report content:', error);
-                modalContent.innerHTML = `<div class="error-message">Error loading report content: ${error.message}</div>`;
+                const errorMessage = DashboardApp._errorMessage(error);
+                modalContent.innerHTML = `<div class="error-message">Error loading report content: ${DashboardApp._escapeHtml(errorMessage)}</div>`;
                 DashboardApp.hideLoading('report-modal-content');
             });
     } else if (format === 'html') {
@@ -108,7 +292,7 @@ DashboardApp.openReport = function(path, format) {
                 htmlContainer.innerHTML = htmlContent;
                 
                 // Remove elements that could break the layout
-                const elementsToRemove = htmlContainer.querySelectorAll('html, head, body, script');
+                const elementsToRemove = htmlContainer.querySelectorAll('html, head, body, script, style, link');
                 elementsToRemove.forEach(el => {
                     if (el.tagName.toLowerCase() === 'body') {
                         // For body, we want to keep its content
@@ -138,7 +322,8 @@ DashboardApp.openReport = function(path, format) {
             })
             .catch(error => {
                 console.error('Error fetching HTML content:', error);
-                modalContent.innerHTML = `<div class="error-message">Error loading HTML content: ${error.message}</div>`;
+                const errorMessage = DashboardApp._errorMessage(error);
+                modalContent.innerHTML = `<div class="error-message">Error loading HTML content: ${DashboardApp._escapeHtml(errorMessage)}</div>`;
                 DashboardApp.hideLoading('report-modal-content');
             });
     } else if (format === 'pdf') {
@@ -171,7 +356,7 @@ DashboardApp.openReport = function(path, format) {
         
         DashboardApp.hideLoading('report-modal-content');
     } else {
-        modalContent.innerHTML = `<div class="format-message">This format (${format.toUpperCase()}) cannot be displayed directly. Use the download option.</div>`;
+        modalContent.innerHTML = `<div class="format-message">This format (${DashboardApp._escapeHtml(String(format).toUpperCase())}) cannot be displayed directly. Use the download option.</div>`;
         DashboardApp.hideLoading('report-modal-content');
     }
     
@@ -179,7 +364,7 @@ DashboardApp.openReport = function(path, format) {
     if (downloadOptions) {
         const basePath = path.substring(0, path.lastIndexOf('.'));
         // Extract the base path without the current format
-        const formatPattern = /\/(md|html|pdf)\//;
+        const formatPattern = /\/(md|html|pdf|json)\//;
         const match = path.match(formatPattern);
         let currentFormat = 'md';
         
@@ -187,19 +372,23 @@ DashboardApp.openReport = function(path, format) {
             currentFormat = match[1];
         }
         
-        // Create the buttons with the correct paths
-        let downloadHtml = '';
-        const formats = {
-            '📝': 'MD',
-            '🌐': 'HTML',
-            '📄': 'PDF'
+        const availableFormats = DashboardApp.getAvailableFormatsForPath(path, currentFormat);
+        const formatLabels = {
+            json: '📋',
+            md: '📝',
+            html: '🌐',
+            pdf: '📄'
         };
-        
-        Object.keys(formats).forEach(fmt => {
-            // Replace the format in the path
-            const formattedPath = basePath.replace(`/${currentFormat}/`, `/${formats[fmt].toLowerCase()}/`) + `.${formats[fmt].toLowerCase()}`;
-            downloadHtml += `<button class="btn btn-format" onclick="downloadReportFile('${formattedPath}', '${fmt}')">
-                           ${fmt} ${formats[fmt]}</button>`;
+
+        let downloadHtml = '';
+        availableFormats.forEach(ext => {
+            const icon = formatLabels[ext];
+            if (!icon) {
+                return;
+            }
+            const formattedPath = basePath.replace(`/${currentFormat}/`, `/${ext}/`) + `.${ext}`;
+            downloadHtml += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(formattedPath)}', '${jsq(ext)}')">
+                           ${icon} ${ext.toUpperCase()}</button>`;
         });
         
         downloadOptions.innerHTML = downloadHtml;

--- a/oasis/static/js/dashboard/modal.js
+++ b/oasis/static/js/dashboard/modal.js
@@ -116,6 +116,10 @@ DashboardApp.getAvailableFormatsForPath = function(path, currentFormat) {
         available.add(String(report.format).toLowerCase());
     }
 
+    const fh = DashboardApp.formatHelpers;
+    if (fh && fh.sortFormatsForDisplay) {
+        return fh.sortFormatsForDisplay(Array.from(available));
+    }
     return Array.from(available);
 };
 
@@ -362,35 +366,53 @@ DashboardApp.openReport = function(path, format) {
     
     // Download options - restaurer le code pour les options de téléchargement
     if (downloadOptions) {
-        const basePath = path.substring(0, path.lastIndexOf('.'));
-        // Extract the base path without the current format
-        const formatPattern = /\/(md|html|pdf|json)\//;
-        const match = path.match(formatPattern);
+        const fh = DashboardApp.formatHelpers;
         let currentFormat = 'md';
-        
-        if (match) {
-            currentFormat = match[1];
+        const folderIdx = fh && fh.reportPathFormatFolderIndex
+            ? fh.reportPathFormatFolderIndex(path)
+            : -1;
+        const segs = path.split('/');
+        if (folderIdx >= 0 && segs[folderIdx]) {
+            currentFormat = String(segs[folderIdx]).toLowerCase();
+        } else if (fh && fh.formatPatternRegexForReportPaths) {
+            const m = path.match(fh.formatPatternRegexForReportPaths());
+            if (m) {
+                currentFormat = m[1].toLowerCase();
+            }
+        } else {
+            const legacy = path.match(/\/(md|html|pdf|json|sarif)\//);
+            if (legacy) {
+                currentFormat = legacy[1].toLowerCase();
+            }
         }
-        
+
         const availableFormats = DashboardApp.getAvailableFormatsForPath(path, currentFormat);
-        const formatLabels = {
-            json: '📋',
-            md: '📝',
-            html: '🌐',
-            pdf: '📄'
-        };
+        const labels = DashboardApp.FORMAT_DOWNLOAD_LABELS || {};
 
         let downloadHtml = '';
         availableFormats.forEach(ext => {
-            const icon = formatLabels[ext];
-            if (!icon) {
-                return;
+            const extLower = String(ext).toLowerCase();
+            const btnLabel = fh && fh.formatDownloadButtonLabel
+                ? fh.formatDownloadButtonLabel(ext)
+                : (String(ext).toUpperCase());
+            const titleUnknown = labels[extLower]
+                ? ''
+                : ` title="${DashboardApp._escapeHtml('Format: ' + ext)}"`;
+            let formattedPath = path;
+            if (fh && fh.reportPathForAlternateFormat) {
+                formattedPath = fh.reportPathForAlternateFormat(path, extLower);
             }
-            const formattedPath = basePath.replace(`/${currentFormat}/`, `/${ext}/`) + `.${ext}`;
-            downloadHtml += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(formattedPath)}', '${jsq(ext)}')">
-                           ${icon} ${ext.toUpperCase()}</button>`;
+            if (formattedPath === path) {
+                const basePath = path.substring(0, path.lastIndexOf('.'));
+                const suffix = fh && fh.downloadArtifactSuffix
+                    ? fh.downloadArtifactSuffix(extLower)
+                    : ('.' + extLower);
+                formattedPath = basePath.replace(`/${currentFormat}/`, `/${extLower}/`) + suffix;
+            }
+            downloadHtml += `<button class="btn btn-format"${titleUnknown} onclick="downloadReportFile('${jsq(formattedPath)}', '${jsq(extLower)}')">
+                           ${btnLabel}</button>`;
         });
-        
+
         downloadOptions.innerHTML = downloadHtml;
     }
 };

--- a/oasis/static/js/dashboard/utils.js
+++ b/oasis/static/js/dashboard/utils.js
@@ -1,6 +1,233 @@
 // Utility functions for the dashboard
 
-DashboardApp.groupReportsByModelAndVuln = function(reports) {
+/** Default display order when ``window.__OASIS_DASHBOARD__`` is absent or incomplete. */
+const DEFAULT_DASHBOARD_FORMAT_ORDER = ['html', 'pdf', 'md', 'json', 'sarif'];
+
+/**
+ * Read and normalize dashboard format lists from ``window.__OASIS_DASHBOARD__`` (single source).
+ * @returns {{ serverOrder: string[], normalizedOutputFormats: string[]|null, allowed: Set<string>|null }}
+ */
+function readNormalizedDashboardFormatConfig() {
+    const cfg = typeof window !== 'undefined' ? window.__OASIS_DASHBOARD__ : null;
+    const serverOrder =
+        cfg && Array.isArray(cfg.formatDisplayOrder) && cfg.formatDisplayOrder.length > 0
+            ? cfg.formatDisplayOrder.map(f => String(f).toLowerCase())
+            : DEFAULT_DASHBOARD_FORMAT_ORDER.slice();
+    const normalizedOutputFormats =
+        cfg && Array.isArray(cfg.outputFormats) && cfg.outputFormats.length > 0
+            ? cfg.outputFormats.map(f => String(f).toLowerCase())
+            : null;
+    const allowed = normalizedOutputFormats ? new Set(normalizedOutputFormats) : null;
+    return { serverOrder, normalizedOutputFormats, allowed };
+}
+
+/**
+ * Register report-format helpers under ``DashboardApp.formatHelpers``.
+ * No visual iconography here — optional ``FORMAT_DOWNLOAD_LABELS`` may be set in bootstrap.js.
+ */
+function registerReportFormatHelpersCore(app) {
+    if (!app) {
+        return false;
+    }
+    if (app.formatHelpers && app.formatHelpers._initialized) {
+        return true;
+    }
+
+    const { serverOrder, normalizedOutputFormats, allowed } = readNormalizedDashboardFormatConfig();
+
+    const fh = {};
+    fh._initialized = true;
+    fh._formatPatternRegex = null;
+    fh._missingFormatLabelWarns = new Set();
+
+    if (allowed) {
+        const ordered = [];
+        const seen = new Set();
+
+        for (const f of serverOrder) {
+            if (allowed.has(f) && !seen.has(f)) {
+                ordered.push(f);
+                seen.add(f);
+            }
+        }
+        for (const f of normalizedOutputFormats) {
+            if (!seen.has(f)) {
+                ordered.push(f);
+                seen.add(f);
+            }
+        }
+
+        fh.REPORT_DOWNLOAD_FORMATS = ordered;
+    } else {
+        fh.REPORT_DOWNLOAD_FORMATS = serverOrder.slice();
+    }
+
+    fh.downloadArtifactSuffix = function(fmt) {
+        const lower = String(fmt || '').toLowerCase();
+        return lower === 'sarif' ? '.sarif' : ('.' + lower);
+    };
+
+    fh._knownFormatFolderNames = function() {
+        const list = fh.REPORT_DOWNLOAD_FORMATS;
+        if (list && list.length) {
+            return new Set(list.map(f => String(f).toLowerCase()));
+        }
+        return new Set(DEFAULT_DASHBOARD_FORMAT_ORDER);
+    };
+
+    fh.reportPathFormatFolderIndex = function(path) {
+        const parts = path.split('/').filter(s => s.length > 0);
+        if (parts.length < 2) {
+            return -1;
+        }
+        const fmtSet = fh._knownFormatFolderNames();
+        const prefer = parts.length - 2;
+        if (fmtSet.has(String(parts[prefer]).toLowerCase())) {
+            return prefer;
+        }
+        for (let i = parts.length - 3; i >= 0; i -= 1) {
+            if (fmtSet.has(String(parts[i]).toLowerCase())) {
+                return i;
+            }
+        }
+        return -1;
+    };
+
+    fh.reportPathForAlternateFormat = function(path, targetFmtLower) {
+        const t = String(targetFmtLower || '').toLowerCase();
+        const parts = path.split('/');
+        const idx = fh.reportPathFormatFolderIndex(path);
+        if (idx < 0) {
+            return path;
+        }
+        const file = parts[parts.length - 1] || '';
+        const stem = file.includes('.') ? file.replace(/\.[^/.]+$/, '') : file;
+        const suffix = fh.downloadArtifactSuffix(t);
+        const next = parts.slice();
+        next[idx] = t;
+        next[next.length - 1] = stem + suffix;
+        return next.join('/');
+    };
+
+    /**
+     * Regex for ``/fmt/`` path segments. Cached; set ``fh._formatPatternRegex = null`` if
+     * ``REPORT_DOWNLOAD_FORMATS`` is ever mutated at runtime.
+     */
+    fh.formatPatternRegexForReportPaths = function() {
+        if (!fh._formatPatternRegex) {
+            const list = Array.from(fh._knownFormatFolderNames());
+            const escaped = list.map(f => f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+            fh._formatPatternRegex = new RegExp('/(' + escaped + ')/');
+        }
+        return fh._formatPatternRegex;
+    };
+
+    fh.formatDownloadButtonLabel = function(fmt) {
+        const lower = String(fmt || '').toLowerCase();
+        const labels = app.FORMAT_DOWNLOAD_LABELS || {};
+        const icon = labels[lower];
+        if (!icon) {
+            if (app.debugMode) {
+                console.warn('[OASIS dashboard] Missing FORMAT_DOWNLOAD_LABELS entry for format:', lower);
+            } else if (!fh._missingFormatLabelWarns.has(lower)) {
+                fh._missingFormatLabelWarns.add(lower);
+                console.warn(
+                    '[OASIS dashboard] Missing FORMAT_DOWNLOAD_LABELS entry for format (once per session):',
+                    lower
+                );
+            }
+            return lower.toUpperCase();
+        }
+        return icon + ' ' + lower.toUpperCase();
+    };
+
+    fh.collectFormatPathsFromReports = function(reports) {
+        const fmts = fh.REPORT_DOWNLOAD_FORMATS;
+        const out = {};
+        fmts.forEach(f => {
+            out[f] = '';
+        });
+        (reports || []).forEach(r => {
+            const af = r.alternative_formats || {};
+            const afLower = {};
+            Object.keys(af).forEach(k => {
+                afLower[String(k).toLowerCase()] = af[k];
+            });
+            const rf = String(r.format || '').toLowerCase();
+            fmts.forEach(fmt => {
+                if (out[fmt]) {
+                    return;
+                }
+                const fl = String(fmt).toLowerCase();
+                const p = rf === fl ? r.path : (af[fmt] || af[fl] || afLower[fl] || '');
+                if (p) {
+                    out[fmt] = p;
+                }
+            });
+        });
+        return out;
+    };
+
+    fh.sortFormatsForDisplay = function(formats) {
+        const order = fh.REPORT_DOWNLOAD_FORMATS || [];
+
+        const formatsLowerToOriginal = {};
+        (formats || []).forEach(f => {
+            const original = String(f);
+            const lower = original.toLowerCase();
+            if (!Object.prototype.hasOwnProperty.call(formatsLowerToOriginal, lower)) {
+                formatsLowerToOriginal[lower] = original;
+            }
+        });
+
+        const orderLowerToOriginal = {};
+        order.forEach(f => {
+            const original = String(f);
+            const lower = original.toLowerCase();
+            if (!Object.prototype.hasOwnProperty.call(orderLowerToOriginal, lower)) {
+                orderLowerToOriginal[lower] = original;
+            }
+        });
+
+        const orderLower = Object.keys(orderLowerToOriginal);
+        const orderLowerSet = new Set(orderLower);
+        const formatsLowerSet = new Set(Object.keys(formatsLowerToOriginal));
+        const sorted = [];
+        const placedFromOrder = new Set();
+
+        orderLower.forEach(lowerFmt => {
+            if (formatsLowerSet.has(lowerFmt) && !placedFromOrder.has(lowerFmt)) {
+                placedFromOrder.add(lowerFmt);
+                const original =
+                    formatsLowerToOriginal[lowerFmt] || orderLowerToOriginal[lowerFmt];
+                sorted.push(original);
+            }
+        });
+
+        formatsLowerSet.forEach(lowerFmt => {
+            if (!orderLowerSet.has(lowerFmt)) {
+                sorted.push(formatsLowerToOriginal[lowerFmt]);
+            }
+        });
+
+        return sorted;
+    };
+
+    app.formatHelpers = fh;
+    return true;
+}
+
+if (typeof DashboardApp !== 'undefined') {
+    DashboardApp.formatHelpers = DashboardApp.formatHelpers || {};
+
+    /**
+     * One-shot registration for ``DashboardApp.formatHelpers`` (call after utils.js loads).
+     */
+    DashboardApp.initFormatHelpers = function() {
+        return registerReportFormatHelpersCore(DashboardApp);
+    };
+
+    DashboardApp.groupReportsByModelAndVuln = function(reports) {
     DashboardApp.debug("Grouping reports by model and vulnerability");
     return reports.map(report => {
         // Extraction of important properties
@@ -18,9 +245,9 @@ DashboardApp.groupReportsByModelAndVuln = function(reports) {
             alternative_formats: alternative_formats || {}
         };
     });
-};
+    };
 
-DashboardApp.buildReportFormatsByPathMap = function(reports) {
+    DashboardApp.buildReportFormatsByPathMap = function(reports) {
     const byPath = {};
 
     (reports || []).forEach(report => {
@@ -31,8 +258,10 @@ DashboardApp.buildReportFormatsByPathMap = function(reports) {
             available.add(String(report.format).toLowerCase());
         }
 
+        const fh = DashboardApp.formatHelpers;
+        const sortFn = fh && fh.sortFormatsForDisplay ? fh.sortFormatsForDisplay : null;
         const payload = {
-            formats: Array.from(available),
+            formats: sortFn ? sortFn(Array.from(available)) : Array.from(available),
             report: report
         };
 
@@ -48,9 +277,9 @@ DashboardApp.buildReportFormatsByPathMap = function(reports) {
 
     DashboardApp.reportFormatsByPath = byPath;
     return byPath;
-};
+    };
 
-DashboardApp.formatDisplayName = function(name, type, emoji = true) {
+    DashboardApp.formatDisplayName = function(name, type, emoji = true) {
     if (!name) {
         return 'Unknown';
     }
@@ -83,9 +312,9 @@ DashboardApp.formatDisplayName = function(name, type, emoji = true) {
         .split(' ')
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join(' ');
-};
+    };
 
-DashboardApp.getModelEmoji = function(model) {
+    DashboardApp.getModelEmoji = function(model) {
     // Try to match by prefix
     for (const [key, emoji] of Object.entries(modelEmojis)) {
         // Check if model starts with key or key starts with model
@@ -97,9 +326,9 @@ DashboardApp.getModelEmoji = function(model) {
     
     // Default emoji if no match found
     return '🤖 ';
-};
+    };
 
-DashboardApp.getVulnerabilityEmoji = function(vulnerability) {
+    DashboardApp.getVulnerabilityEmoji = function(vulnerability) {
     // Try to match by prefix
     for (const [key, emoji] of Object.entries(vulnEmojis)) {
         if (vulnerability.toLowerCase().startsWith(key.toLowerCase()) || 
@@ -110,6 +339,7 @@ DashboardApp.getVulnerabilityEmoji = function(vulnerability) {
     
     // Default emoji if no match found
     return '🔒 ';
-};
+    };
 
-DashboardApp.debug("Utils module loaded"); 
+    DashboardApp.debug('Utils module loaded');
+}

--- a/oasis/static/js/dashboard/utils.js
+++ b/oasis/static/js/dashboard/utils.js
@@ -1,4 +1,5 @@
 // Utility functions for the dashboard
+
 DashboardApp.groupReportsByModelAndVuln = function(reports) {
     DashboardApp.debug("Grouping reports by model and vulnerability");
     return reports.map(report => {
@@ -13,10 +14,40 @@ DashboardApp.groupReportsByModelAndVuln = function(reports) {
             date,
             format,
             date_visible: date_visible !== undefined ? date_visible : true,
-            stats: stats || { high_risk: 0, medium_risk: 0, low_risk: 0, total: 0 },
+            stats: stats || { high_risk: 0, medium_risk: 0, low_risk: 0, total_findings: 0, files_analyzed: 0 },
             alternative_formats: alternative_formats || {}
         };
     });
+};
+
+DashboardApp.buildReportFormatsByPathMap = function(reports) {
+    const byPath = {};
+
+    (reports || []).forEach(report => {
+        const available = new Set();
+        const alternatives = report.alternative_formats || {};
+        Object.keys(alternatives).forEach(fmt => available.add(String(fmt).toLowerCase()));
+        if (report.format) {
+            available.add(String(report.format).toLowerCase());
+        }
+
+        const payload = {
+            formats: Array.from(available),
+            report: report
+        };
+
+        if (report.path) {
+            byPath[report.path] = payload;
+        }
+        Object.values(alternatives).forEach(path => {
+            if (path) {
+                byPath[path] = payload;
+            }
+        });
+    });
+
+    DashboardApp.reportFormatsByPath = byPath;
+    return byPath;
 };
 
 DashboardApp.formatDisplayName = function(name, type, emoji = true) {

--- a/oasis/static/js/dashboard/views.js
+++ b/oasis/static/js/dashboard/views.js
@@ -306,23 +306,12 @@ DashboardApp.renderListViewWithTemplate = function() {
         const mediumRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.medium_risk || 0), 0);
         const lowRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.low_risk || 0), 0);
         
-        // Determine format paths for buttons
-        let jsonPath = '';
-        let mdPath = '';
-        let htmlPath = '';
-        let pdfPath = '';
-        
-        // Get the latest report for each format
+        // Resolve download paths across all report rows (same stem may appear as json, md, sarif, …)
         reportsForVuln.sort((a, b) => new Date(b.date) - new Date(a.date));
-        const latestReport = reportsForVuln[0];
-        
-        if (latestReport) {
-            const af = latestReport.alternative_formats || {};
-            jsonPath = latestReport.format === 'json' ? latestReport.path : (af.json || '');
-            mdPath = latestReport.format === 'md' ? latestReport.path : (af.md || '');
-            htmlPath = latestReport.format === 'html' ? latestReport.path : (af.html || '');
-            pdfPath = latestReport.format === 'pdf' ? latestReport.path : (af.pdf || '');
-        }
+        const fh = DashboardApp.formatHelpers;
+        const formatPaths = fh && fh.collectFormatPathsFromReports
+            ? fh.collectFormatPathsFromReports(reportsForVuln)
+            : {};
                 
         // Generate models HTML
         let modelsHTML = '';
@@ -358,20 +347,23 @@ DashboardApp.renderListViewWithTemplate = function() {
             }
         });
             
-        // Generate format buttons HTML
+        // Generate format buttons HTML (order from REPORT_DOWNLOAD_FORMATS: human-readable first)
         let formatButtons = '';
-        if (pdfPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(pdfPath)}', 'pdf')">📄 PDF</button>`;
-        }
-        if (jsonPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(jsonPath)}', 'json')">📋 JSON</button>`;
-        }
-        if (mdPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(mdPath)}', 'md')">📝 MD</button>`;
-        }
-        if (htmlPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(htmlPath)}', 'html')">🌐 HTML</button>`;
-        }
+        const fmts = (fh && fh.REPORT_DOWNLOAD_FORMATS) || [];
+        fmts.forEach(fmt => {
+            const p = formatPaths[fmt];
+            if (!p) {
+                return;
+            }
+            const btnLabel = fh && fh.formatDownloadButtonLabel
+                ? fh.formatDownloadButtonLabel(fmt)
+                : String(fmt).toUpperCase();
+            const fmtLower = String(fmt).toLowerCase();
+            const titleUnknown = (DashboardApp.FORMAT_DOWNLOAD_LABELS || {})[fmtLower]
+                ? ''
+                : ` title="${h('Format: ' + fmt)}"`;
+            formatButtons += `<button class="btn btn-format"${titleUnknown} onclick="downloadReportFile('${jsq(p)}', '${jsq(fmt)}')">${btnLabel}</button>`;
+        });
             
         // Use the template and replace placeholders
         let cardHTML = DashboardApp.cardTemplate

--- a/oasis/static/js/dashboard/views.js
+++ b/oasis/static/js/dashboard/views.js
@@ -29,6 +29,8 @@ DashboardApp.renderCurrentView = function() {
 
 DashboardApp.renderTreeView = function(groupBy) {
     DashboardApp.debug("Rendering tree view...");
+    const h = DashboardApp._escapeHtml;
+    const openReportOnclick = DashboardApp._buildOpenReportOnclick;
     const container = document.getElementById('reports-container');
     
     if (!container) {
@@ -76,7 +78,7 @@ DashboardApp.renderTreeView = function(groupBy) {
     // For each group (model or vulnerability type)
     sortedKeys.forEach(key => {
         const reportsInGroup = grouped[key];
-        const formattedKey = DashboardApp.formatDisplayName(key, groupBy === 'model' ? 'model' : 'vulnerability');
+        const formattedKey = h(DashboardApp.formatDisplayName(key, groupBy === 'model' ? 'model' : 'vulnerability'));
         
         html += `
             <div class="tree-section">
@@ -102,7 +104,7 @@ DashboardApp.renderTreeView = function(groupBy) {
             
             sortedModels.forEach(model => {
                 const reportsForModel = modelGroups[model];
-                const formattedModel = DashboardApp.formatDisplayName(model, 'model');
+                const formattedModel = h(DashboardApp.formatDisplayName(model, 'model'));
                 
                 html += `
                     <div class="tree-item">
@@ -117,15 +119,18 @@ DashboardApp.renderTreeView = function(groupBy) {
                 
                 // Add date entries
                 reportsForModel.forEach(report => {
+                    if (!report.date_visible) {
+                        return;
+                    }
                     const reportDate = report.date ? new Date(report.date) : null;
                     const formattedDate = reportDate ? reportDate.toLocaleDateString() : 'No date';
                     const formattedTime = reportDate ? reportDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
                     
                     html += `
                         <span class="date-tag clickable" 
-                            onclick="openReport('${report.path}', '${report.format}')" 
-                            data-model="${model}" 
-                            data-vulnerability="${report.vulnerability_type}">
+                            onclick="${openReportOnclick(report.path, report.format)}" 
+                            data-model="${h(model)}" 
+                            data-vulnerability="${h(report.vulnerability_type)}">
                             <div class="date-main">${formattedDate}</div>
                             <div class="date-time">${formattedTime}</div>
                         </span>
@@ -168,7 +173,7 @@ DashboardApp.renderTreeView = function(groupBy) {
             
             sortedVulns.forEach(vuln => {
                 const reportsForVuln = vulnGroups[vuln];
-                const formattedVuln = DashboardApp.formatDisplayName(vuln, 'vulnerability');
+                const formattedVuln = h(DashboardApp.formatDisplayName(vuln, 'vulnerability'));
                 
                 html += `
                     <div class="tree-item">
@@ -183,15 +188,18 @@ DashboardApp.renderTreeView = function(groupBy) {
                 
                 // Add date entries
                 reportsForVuln.forEach(report => {
+                    if (!report.date_visible) {
+                        return;
+                    }
                     const reportDate = report.date ? new Date(report.date) : null;
                     const formattedDate = reportDate ? reportDate.toLocaleDateString() : 'No date';
                     const formattedTime = reportDate ? reportDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
                     
                     html += `
                         <span class="date-tag clickable" 
-                            onclick="openReport('${report.path}', '${report.format}')" 
-                            data-model="${report.model}" 
-                            data-vulnerability="${vuln}">
+                            onclick="${openReportOnclick(report.path, report.format)}" 
+                            data-model="${h(report.model)}" 
+                            data-vulnerability="${h(vuln)}">
                             <div class="date-main">${formattedDate}</div>
                             <div class="date-time">${formattedTime}</div>
                         </span>
@@ -248,6 +256,9 @@ DashboardApp.renderListView = function() {
 
 DashboardApp.renderListViewWithTemplate = function() {
     DashboardApp.debug("Rendering list view with template...");
+    const h = DashboardApp._escapeHtml;
+    const jsq = DashboardApp._escapeJsSingleQuote;
+    const openReportOnclick = DashboardApp._buildOpenReportOnclick;
     const container = document.getElementById('reports-container');
     
     // Group by vulnerability type
@@ -280,19 +291,23 @@ DashboardApp.renderListViewWithTemplate = function() {
     
     sortedVulns.forEach(vuln => {
         const reportsForVuln = vulnGroups[vuln];
-        const formattedVulnEmoji = DashboardApp.formatDisplayName(vuln, 'vulnerability');
-        const formattedVuln = DashboardApp.formatDisplayName(vuln, 'vulnerability', false);
+        const formattedVulnEmoji = h(DashboardApp.formatDisplayName(vuln, 'vulnerability'));
+        const formattedVuln = h(DashboardApp.formatDisplayName(vuln, 'vulnerability', false));
         
         // Group models for this vulnerability
         const models = [...new Set(reportsForVuln.map(report => report.model))];
         
         // Get report statistics
-        const totalFindings = reportsForVuln.reduce((sum, r) => sum + (r.stats?.total || 0), 0);
+        const totalFindings = reportsForVuln.reduce(
+            (sum, r) => sum + (r.stats?.total_findings ?? r.stats?.total ?? 0),
+            0
+        );
         const highRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.high_risk || 0), 0);
         const mediumRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.medium_risk || 0), 0);
         const lowRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.low_risk || 0), 0);
         
         // Determine format paths for buttons
+        let jsonPath = '';
         let mdPath = '';
         let htmlPath = '';
         let pdfPath = '';
@@ -302,29 +317,22 @@ DashboardApp.renderListViewWithTemplate = function() {
         const latestReport = reportsForVuln[0];
         
         if (latestReport) {
-            // Format paths
-            mdPath = latestReport.format === 'md' ? latestReport.path : 
-                    (latestReport.alternative_formats && latestReport.alternative_formats.md ? 
-                    latestReport.alternative_formats.md : '');
-            
-            htmlPath = latestReport.format === 'html' ? latestReport.path : 
-                    (latestReport.alternative_formats && latestReport.alternative_formats.html ? 
-                    latestReport.alternative_formats.html : '');
-            
-            pdfPath = latestReport.format === 'pdf' ? latestReport.path : 
-                    (latestReport.alternative_formats && latestReport.alternative_formats.pdf ? 
-                    latestReport.alternative_formats.pdf : '');
+            const af = latestReport.alternative_formats || {};
+            jsonPath = latestReport.format === 'json' ? latestReport.path : (af.json || '');
+            mdPath = latestReport.format === 'md' ? latestReport.path : (af.md || '');
+            htmlPath = latestReport.format === 'html' ? latestReport.path : (af.html || '');
+            pdfPath = latestReport.format === 'pdf' ? latestReport.path : (af.pdf || '');
         }
                 
         // Generate models HTML
         let modelsHTML = '';
         models.forEach(model => {
-            const formattedModel = DashboardApp.formatDisplayName(model, 'model');
+            const formattedModel = h(DashboardApp.formatDisplayName(model, 'model'));
             
             modelsHTML += `
                 <span class="model-tag clickable" 
                     onclick="filterDatesByModel(this)" 
-                    data-model="${model}">
+                    data-model="${h(model)}">
                     ${formattedModel}
                 </span>
             `;
@@ -341,8 +349,8 @@ DashboardApp.renderListViewWithTemplate = function() {
                 
                 datesHTML += `
                     <span class="date-tag clickable" 
-                        onclick="openReport('${report.path}', '${report.format}')" 
-                        data-model="${report.model}">
+                        onclick="${openReportOnclick(report.path, report.format)}" 
+                        data-model="${h(report.model)}">
                         <div class="date-main">${formattedDate}</div>
                         <div class="date-time">${formattedTime}</div>
                     </span>
@@ -353,13 +361,16 @@ DashboardApp.renderListViewWithTemplate = function() {
         // Generate format buttons HTML
         let formatButtons = '';
         if (pdfPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${pdfPath}', 'pdf')">📄 PDF</button>`;
+          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(pdfPath)}', 'pdf')">📄 PDF</button>`;
+        }
+        if (jsonPath) {
+          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(jsonPath)}', 'json')">📋 JSON</button>`;
         }
         if (mdPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${mdPath}', 'md')">📝 MD</button>`;
+          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(mdPath)}', 'md')">📝 MD</button>`;
         }
         if (htmlPath) {
-          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${htmlPath}', 'html')">🌐 HTML</button>`;
+          formatButtons += `<button class="btn btn-format" onclick="downloadReportFile('${jsq(htmlPath)}', 'html')">🌐 HTML</button>`;
         }
             
         // Use the template and replace placeholders

--- a/oasis/structured_output/__init__.py
+++ b/oasis/structured_output/__init__.py
@@ -1,0 +1,7 @@
+"""
+Structured LLM output for ChunkDeepAnalysis: field normalization, prompts, and JSON repair.
+
+- ``deep`` — path-based normalizers, retry heuristics, instruction blocks.
+- ``json_repair`` — markdown fence stripping, decode/repair pipeline, safe-minimal fallback.
+- ``json_repair_scan`` — low-level delimiter and escape scanners (used by ``json_repair``).
+"""

--- a/oasis/structured_output/deep.py
+++ b/oasis/structured_output/deep.py
@@ -1,0 +1,222 @@
+"""
+Declarative helpers for ChunkDeepAnalysis structured LLM output.
+
+Centralizes:
+- Path-based field normalizers (list -> string, etc.)
+- Retry heuristics tied to specific schema locations (e.g. findings.*.exploitation_conditions)
+- Shared prompt / retry-suffix text so normalization, retry, and instructions stay aligned.
+
+**Extending path normalizers**
+
+Register at import time (e.g. plugin or ``analyze`` setup). Use ``*`` to map over one list
+level. Normalizers should return an equivalent value when no change is needed so diffs
+stay small::
+
+    register_chunk_deep_normalizer(
+        ("findings", "*", "http_methods"),
+        lambda v: "; ".join(v) if isinstance(v, list) else v,
+    )
+
+Mutations are applied in place on the parsed dict; do not stash shared mutable defaults
+on the callable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Tuple
+
+# Path tuples: "*" traverses every element of a JSON array at that position.
+EXPLOITATION_CONDITIONS_PATH: Tuple[str, ...] = ("findings", "*", "exploitation_conditions")
+
+
+def _coerce_exploitation_conditions_list(value: Any) -> Any:
+    if isinstance(value, list):
+        return "; ".join(str(item) for item in value)
+    return value
+
+
+# Declarative registry: extend by adding (path_tuple, normalizer).
+# Normalizers at a leaf receive the current value; list coercion helpers expect a list.
+CHUNK_DEEP_LIST_FIELD_NORMALIZERS: Dict[Tuple[str, ...], Callable[[Any], Any]] = {
+    EXPLOITATION_CONDITIONS_PATH: _coerce_exploitation_conditions_list,
+}
+
+
+def register_chunk_deep_normalizer(
+    path: Tuple[str, ...],
+    normalizer: Callable[[Any], Any],
+) -> None:
+    """Register or replace a path-based normalizer (typically list coercion at a leaf)."""
+    CHUNK_DEEP_LIST_FIELD_NORMALIZERS[path] = normalizer
+
+
+def apply_normalizer_by_path(
+    payload: Any,
+    path: Tuple[str, ...],
+    normalizer: Callable[[Any], Any],
+) -> bool:
+    """
+    Walk payload along ``path`` and apply ``normalizer`` at the leaf for each matching node.
+
+    Returns True if any leaf value was changed. Wildcard ``*`` expands one list level.
+    """
+    if not path:
+        return False
+    token = path[0]
+    remaining = path[1:]
+    changed = False
+
+    if token == "*":
+        # Wildcard: exactly one list level. Non-list payloads are a silent no-op (registry
+        # paths like ``("findings", "*", ...)`` assume ``findings`` is a list of dicts).
+        # Non-dict elements in that list are skipped when descending with the remaining path.
+        if isinstance(payload, list):
+            for item in payload:
+                if apply_normalizer_by_path(item, remaining, normalizer):
+                    changed = True
+        return changed
+
+    if not isinstance(payload, dict) or token not in payload:
+        return False
+
+    if not remaining:
+        current = payload[token]
+        if isinstance(current, list):
+            new_val = normalizer(current)
+            if new_val != current:
+                payload[token] = new_val
+                return True
+        return False
+
+    return apply_normalizer_by_path(payload[token], remaining, normalizer)
+
+
+def chunk_deep_normalization_change_samples(
+    before: Dict[str, Any],
+    after: Dict[str, Any],
+    *,
+    max_items: int = 5,
+) -> List[Dict[str, Any]]:
+    """
+    Build a small list of ``{path, before, after}`` for finding entries that changed.
+
+    Used for debug logging after in-place normalization (e.g. list→string coercion).
+    """
+    out: List[Dict[str, Any]] = []
+    b_f = before.get("findings")
+    a_f = after.get("findings")
+    if not isinstance(b_f, list) or not isinstance(a_f, list):
+        return out
+    for i, (item_b, item_a) in enumerate(zip(b_f, a_f)):
+        if len(out) >= max_items:
+            break
+        if not isinstance(item_b, dict) or not isinstance(item_a, dict):
+            continue
+        for key in sorted(set(item_b) | set(item_a)):
+            if len(out) >= max_items:
+                break
+            vb, va = item_b.get(key), item_a.get(key)
+            if vb != va:
+                out.append({"path": f"findings[{i}].{key}", "before": vb, "after": va})
+    return out
+
+
+def normalize_chunk_deep_payload_dict(payload: Dict[str, Any]) -> List[str]:
+    """
+    Apply all entries in ``CHUNK_DEEP_LIST_FIELD_NORMALIZERS``.
+
+    Returns dotted path labels (for logging) for each rule that changed the payload.
+    """
+    normalized_fields: List[str] = []
+    normalized_fields.extend(
+        ".".join(path)
+        for path, normalizer in CHUNK_DEEP_LIST_FIELD_NORMALIZERS.items()
+        if apply_normalizer_by_path(payload, path, normalizer)
+    )
+    return normalized_fields
+
+
+def validation_detail_is_exploitation_conditions_retryable(detail: dict) -> bool:
+    """
+    True when this ValidationError detail is a known recoverable shape for exploitation_conditions.
+
+    Uses structured ``loc`` / ``type`` / ``msg`` only (not the stringified full error).
+    """
+    loc = detail.get("loc") or ()
+    err_type = str(detail.get("type", ""))
+    err_msg = str(detail.get("msg", "")).lower()
+    return (
+        len(loc) >= 3
+        and loc[0] == "findings"
+        and isinstance(loc[1], int)
+        and loc[2] == EXPLOITATION_CONDITIONS_PATH[-1]
+        and (
+            "string_type" in err_type
+            or "field required" in err_msg
+            or "value_error.missing" in err_type
+        )
+    )
+
+
+# Compact rules shared in meaning with ``chunk_deep_prompt_output_constraint_block`` (keep both aligned).
+CHUNK_DEEP_SCHEMA_TYPE_RULES_COMPACT = (
+    "Respect schema types (string fields as JSON strings, never arrays/objects); "
+    "exploitation_conditions must be one string sentence, not a list; "
+    "use \\n and \\\" inside strings as needed; "
+    "if uncertain return "
+    '{"findings": [], "notes": "Unable to produce confident structured output", '
+    '"validation_error": true, "potential_vulnerabilities": true, "truncated": false}; '
+    "only standard JSON string escapes (\\\\ \\\" \\/ \\b \\f \\n \\r \\t \\uXXXX); "
+    "no markdown fences in values; the response must end at the root object's closing `}`.\n"
+)
+
+
+def _shared_structured_retry_body() -> str:
+    """Lines shared by generic and ChunkDeepAnalysis retry suffixes."""
+    return (
+        "Return valid JSON only (single object matching the required schema).\n"
+        "Do NOT use markdown code fences.\n"
+        "Return compact JSON with no explanations, no repeated filler tokens, and no trailing commentary.\n"
+        "Ensure every quote/bracket is closed and output ends with the final '}' of the JSON object.\n"
+        + CHUNK_DEEP_SCHEMA_TYPE_RULES_COMPACT
+        + "Never include raw multi-line code with unescaped quotes in JSON string fields.\n"
+    )
+
+
+def generic_structured_retry_suffix() -> str:
+    """Retry reminder for non-ChunkDeepAnalysis structured models (e.g. MediumRiskAnalysis)."""
+    return "\n\nCORRECTION: " + _shared_structured_retry_body()
+
+
+def chunk_deep_structured_retry_suffix() -> str:
+    """Retry reminder including ChunkDeepAnalysis-specific field typing (exploitation_conditions)."""
+    return (
+        "\n\nCORRECTION: "
+        + _shared_structured_retry_body()
+        + "Example: exploitation_conditions must be a single string, not a list.\n"
+    )
+
+
+def chunk_deep_prompt_output_constraint_block() -> str:
+    """
+    Bullet block for the \"Output constraints\" section of deep structured instructions.
+
+    Keep in sync with ``CHUNK_DEEP_SCHEMA_TYPE_RULES_COMPACT`` and ``chunk_deep_structured_retry_suffix``.
+    """
+    # Detailed bullets for the model; typing intent matches CHUNK_DEEP_SCHEMA_TYPE_RULES_COMPACT.
+    return """Output constraints (strict):
+- Return JSON ONLY, exactly one object, no prose before or after.
+- Keep values concise to avoid truncation; prioritize complete valid JSON over verbosity.
+- Never repeat filler tokens (e.g. "the the the"), and never emit partial or unfinished strings.
+- Ensure the response ends with a fully closed JSON object (`}` as appropriate).
+- Follow field types exactly as defined in the schema.
+- If a schema field is type string, output a single string value, never an array or object.
+- exploitation_conditions MUST be a single string sentence (not list).
+- Keep `secure_code_example` short (max 5 lines) and escape line breaks as `\\n` inside JSON.
+- Escape any `\\"` characters inside string values; never emit raw unescaped `"` inside a JSON string.
+- Avoid long prose in `notes`; keep one short sentence (max 20 words).
+- Do not include markdown fences, backticks, or pseudo-JSON fragments inside any field value.
+- Do NOT include markdown code fences (``` or similar) anywhere inside field values.
+- The last character of the entire response must be the root object's closing `}`; no trailing text.
+- Inside strings use only valid JSON escapes; do not emit `\\x`, `\\'`, or invalid `\\` + letter sequences (use `\\\\` for a literal backslash).
+- If you are genuinely uncertain or the context is too ambiguous to populate fields confidently, return a minimal object like {"findings": [], "notes": "Unable to produce confident structured output", "validation_error": true, "potential_vulnerabilities": true, "truncated": false}."""

--- a/oasis/structured_output/json_repair.py
+++ b/oasis/structured_output/json_repair.py
@@ -1,0 +1,270 @@
+"""
+Low-level JSON repair for ChunkDeepAnalysis model output only.
+
+``SecurityAnalyzer`` delegates here so orchestration stays separate from string parsing.
+All public entry points assume the caller already verified ``ChunkDeepAnalysis`` intent.
+
+**Pipeline (``repair_chunk_deep_structured_json_raw``)**
+
+1. ``strip_code_fences`` — outer markdown wrapper only (opening line + one trailing fence).
+2. ``strip_control_chars`` — remove illegal C0 controls.
+3. ``extract_first_json_object_candidate`` — drop preamble before the first ``{``.
+4. ``decode_chunk_deep_json_object`` — fast path when the buffer is already valid JSON.
+5. ``apply_structured_json_repair_steps`` — balance ``{``/``[`` (see ``json_repair_scan``), strip
+   trailing commas (same submodule).
+6. ``decode_chunk_deep_json_object`` again on the repaired string.
+7. ``fix_invalid_json_string_escapes`` (``json_repair_scan``) — fix invalid ``\\`` sequences inside strings.
+8. ``build_safe_minimal_chunk_json`` — last-resort empty findings + notes, or return best-effort text.
+
+Character-level scanners live in ``json_repair_scan`` (state machines, ASCII sketches there).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from contextlib import suppress
+from typing import Any, Dict, Optional
+
+from .json_repair_scan import (
+    fix_invalid_json_string_escapes,
+    scan_open_delimiter_stack_outside_strings,
+    strip_trailing_commas_outside_strings,
+)
+from ..tools import logger
+
+
+def strip_code_fences(candidate: str) -> str:
+    """
+    Strip an outer markdown fence only when the opening line is a fence line (optionally ``json``).
+
+    Inline backticks on the same line as content are not treated as opening fences.
+
+    The closing fence is removed **at most once** and only when it appears at the **very
+    end** of the buffer (after the opening line was stripped). We do not scan for ``^`````
+    on every line, because a JSON string value may legally contain a newline followed by
+    `` ``` `` at column zero (e.g. embedded markdown examples).
+    """
+    if not candidate.startswith("```"):
+        return candidate
+    # Opening: first line of the buffer only (no MULTILINE — avoids matching inner lines).
+    candidate = re.sub(
+        r"^```(?:json)?\s*$\n?",
+        "",
+        candidate,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    # Closing: one trailing fence line only (not every ```-only line in the payload).
+    candidate = re.sub(r"\r?\n?```\s*$", "", candidate, count=1)
+    return candidate
+
+
+def strip_control_chars(candidate: str) -> str:
+    """Remove C0 control characters except tab/newline, which often break ``json.loads``."""
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", candidate)
+
+
+def extract_first_json_object_candidate(candidate: str) -> str:
+    """Drop leading non-JSON noise before the first ``{`` (e.g. model preamble text)."""
+    first_obj = candidate.find("{")
+    return candidate[first_obj:] if first_obj > 0 else candidate
+
+
+def _delimiter_structural_failure_fallback(candidate: str) -> str:
+    """
+    When delimiter scanning finds an impossible structure, avoid appending bogus closers.
+
+    Prefer a minimal valid ChunkDeepAnalysis-shaped payload when ``findings`` is present;
+    otherwise return ``candidate`` unchanged for later repair stages.
+
+    Example: ``{]`` would parse as balanced if we naively appended ``}``; we instead
+    emit safe-minimal when ``"findings"`` is present so downstream validation stays honest.
+    """
+    minimal = build_safe_minimal_chunk_json(candidate)
+    return minimal if minimal is not None else candidate
+
+
+def balance_json_delimiters_outside_strings(candidate: str) -> str:
+    """
+    Append missing closing ``}`` / ``]`` only when ``scan_open_delimiter_stack_outside_strings``
+    reports a consistent open stack.
+
+    If the scan returns ``None``, we do **not** append artificial closers: that can yield
+    syntactically valid but misleading JSON. In those cases we fall back to
+    ``build_safe_minimal_chunk_json`` when possible.
+
+    Assumptions and limits:
+    - Treats ``"`` as string delimiter only; does not support JSON5 single-quoted strings.
+    - Escape handling is limited to ``\\`` before ``"`` inside strings (standard JSON escaping).
+      Malformed escape sequences can still desynchronize the in-string state.
+    - Best-effort for *truncated* output with consistent open containers left on the stack.
+    """
+    stack = scan_open_delimiter_stack_outside_strings(candidate)
+    if stack is None:
+        # e.g. ``{]``, extra ``}``, or ``{"k":"`` — appending ``}`` would hide the real failure.
+        return _delimiter_structural_failure_fallback(candidate)
+    suffix = "".join("}" if op == "{" else "]" for op in reversed(stack))
+    return candidate + suffix
+
+
+def apply_structured_json_repair_steps(candidate: str) -> str:
+    """
+    Run structural repairs: balance delimiters, then strip trailing commas.
+
+    Order matters: balancing first can expose comma issues before closers.
+    """
+    candidate = balance_json_delimiters_outside_strings(candidate)
+    candidate = strip_trailing_commas_outside_strings(candidate)
+    return candidate
+
+
+def decode_chunk_deep_json_object(candidate: str) -> Optional[Dict[str, Any]]:
+    """
+    Parse the first JSON object from ``candidate``.
+
+    Uses ``json.loads`` when the full buffer is valid, otherwise ``JSONDecoder.raw_decode``
+    to drop trailing garbage (common LLM failure: valid object + extra prose).
+    """
+    if not candidate.strip():
+        return None
+    with suppress(json.JSONDecodeError, TypeError, ValueError):
+        obj = json.loads(candidate)
+        if isinstance(obj, dict):
+            return obj
+    decoder = json.JSONDecoder()
+    with suppress(json.JSONDecodeError, TypeError, ValueError):
+        obj, _end = decoder.raw_decode(candidate.strip())
+        if isinstance(obj, dict):
+            return obj
+    return None
+
+
+def build_safe_minimal_chunk_json(raw: str) -> Optional[str]:
+    """
+    Build a safe minimal ChunkDeepAnalysis payload when repair cannot recover.
+
+    ``notes`` extraction order:
+    1. ``decode_chunk_deep_json_object(raw)`` — first object + tolerates trailing noise.
+    2. ``json.loads(raw)`` — full-document parse when the buffer is valid JSON.
+    3. Regex ``"notes"\\s*:\\s*"([^"]*)"`` — last resort on broken syntax; may truncate
+       if the value contains an unescaped ``"`` (rare on this failure path).
+    """
+    if not re.search(r'"findings"\s*:', raw):
+        return None
+
+    notes_source: Optional[str] = None
+    decoded = decode_chunk_deep_json_object(raw)
+    if isinstance(decoded, dict):
+        n = decoded.get("notes")
+        if isinstance(n, str):
+            notes_source = n
+    if notes_source is None:
+        with suppress(json.JSONDecodeError, TypeError, ValueError):
+            loaded = json.loads(raw.strip())
+            if isinstance(loaded, dict):
+                n = loaded.get("notes")
+                if isinstance(n, str):
+                    notes_source = n
+    if notes_source is None:
+        if note_match := re.search(r'"notes"\s*:\s*"([^"]*)"', raw, flags=re.DOTALL):
+            notes_source = note_match.group(1)
+
+    notes = "Model returned malformed JSON; findings omitted."
+    if isinstance(notes_source, str):
+        extracted = notes_source.strip().replace("\n", " ").replace("\r", " ")
+        if extracted := re.sub(r"\s+", " ", extracted):
+            notes = extracted[:220]
+
+    payload = {
+        "findings": [],
+        "notes": notes,
+        "validation_error": True,
+        "potential_vulnerabilities": True,
+        "truncated": True,
+    }
+    return json.dumps(payload)
+
+
+def repair_chunk_deep_structured_json_raw(raw: str, *, model_display: str) -> str:
+    """
+    Repair malformed JSON intended for ``ChunkDeepAnalysis``.
+
+    Caller must ensure this path is only used for ChunkDeepAnalysis outputs.
+
+    Preserves progressive cleanup in the returned string when possible: if no parseable
+    object and safe-minimal cannot be built, returns the best-effort repaired string
+    (fence/control-char stripped, balanced, escape-fixed) rather than the original ``raw``.
+    """
+    if not raw:
+        return raw
+
+    original_raw = raw
+    candidate = strip_code_fences(raw.strip())
+    candidate = strip_control_chars(candidate)
+    candidate = extract_first_json_object_candidate(candidate)
+
+    def dump_normalized(obj: Dict[str, Any]) -> str:
+        return json.dumps(obj, ensure_ascii=False)
+
+    decoded = decode_chunk_deep_json_object(candidate)
+    if decoded is not None:
+        if candidate != raw.strip():
+            logger.debug("Applied light JSON cleanup for deep structured output (%s)", model_display)
+        return dump_normalized(decoded)
+
+    repaired = apply_structured_json_repair_steps(candidate)
+    decoded = decode_chunk_deep_json_object(repaired)
+    if decoded is not None:
+        logger.debug("Applied JSON repair heuristics for deep structured output (%s)", model_display)
+        return dump_normalized(decoded)
+
+    escaped = fix_invalid_json_string_escapes(repaired)
+    if escaped != repaired:
+        decoded = decode_chunk_deep_json_object(escaped)
+        if decoded is not None:
+            logger.debug(
+                "Applied invalid-escape fix for deep structured output (%s)",
+                model_display,
+            )
+            return dump_normalized(decoded)
+
+    # Prefer a minimal valid object when we see ``"findings"`` (ChunkDeep-shaped garbage).
+    safe_minimal = build_safe_minimal_chunk_json(repaired)
+    if safe_minimal is None:
+        safe_minimal = build_safe_minimal_chunk_json(escaped)
+    if safe_minimal is None:
+        # No ``"findings"`` hint: synthetic minimal would be misleading; return the most
+        # repaired buffer we have (fences/controls stripped, balance/escapes attempted)
+        # so logs and any downstream retry still see progress vs. raw model output.
+        best_effort = escaped if escaped != repaired else repaired
+        if best_effort and best_effort != original_raw.strip():
+            logger.debug(
+                "Deep JSON repair returning best-effort string (no safe-minimal) (%s)",
+                model_display,
+            )
+            return best_effort
+        return original_raw
+
+    # Parsed object still invalid but buffer looked like a chunk report: empty findings
+    # + extracted notes beats failing the whole chunk (see ``build_safe_minimal_chunk_json``).
+    logger.debug(
+        "Falling back to safe minimal deep JSON after repair failure (%s)",
+        model_display,
+    )
+    return safe_minimal
+
+
+__all__ = [
+    "apply_structured_json_repair_steps",
+    "balance_json_delimiters_outside_strings",
+    "build_safe_minimal_chunk_json",
+    "decode_chunk_deep_json_object",
+    "extract_first_json_object_candidate",
+    "fix_invalid_json_string_escapes",
+    "repair_chunk_deep_structured_json_raw",
+    "scan_open_delimiter_stack_outside_strings",
+    "strip_code_fences",
+    "strip_control_chars",
+    "strip_trailing_commas_outside_strings",
+]

--- a/oasis/structured_output/json_repair_scan.py
+++ b/oasis/structured_output/json_repair_scan.py
@@ -1,0 +1,234 @@
+"""
+Character-level scanners for JSON-ish repair (ChunkDeepAnalysis buffers only).
+
+No ``json.loads``, no markdown fences, no ``logger``. Used by
+``oasis.structured_output.json_repair`` in this order as part of the larger pipeline:
+
+    strip fences / controls / leading noise  (in the parent module)
+    → try ``decode_chunk_deep_json_object``
+    → balance delimiters (uses ``scan_open_delimiter_stack_outside_strings``)
+    → ``strip_trailing_commas_outside_strings``
+    → ``fix_invalid_json_string_escapes``
+    → ``build_safe_minimal_chunk_json`` / best-effort return (parent module)
+
+``json_repair`` re-exports public names so tests and callers can import from there.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _is_simple_json_escape_char(next_char: str) -> bool:
+    """True if ``\\`` + this char is a standard single-character JSON escape."""
+    return next_char in '"\\/bfnrt'
+
+
+def _is_unicode_escape_at(s: str, backslash_index: int) -> bool:
+    """
+    True if ``s[backslash_index:]`` begins ``\\uXXXX`` with four hex digits.
+
+    ``backslash_index`` points at the backslash inside a JSON string.
+    """
+    if backslash_index + 6 > len(s) or s[backslash_index + 1] != "u":
+        return False
+    return all(c in _HEX_DIGITS for c in s[backslash_index + 2 : backslash_index + 6])
+
+
+def scan_open_delimiter_stack_outside_strings(candidate: str) -> Optional[List[str]]:
+    """
+    Walk ``candidate`` and track ``{``/``[`` stack outside JSON double-quoted strings.
+
+    **Pre:** ``candidate`` is the buffer to scan (may be truncated LLM output).
+
+    **Post:**
+    - Returns a list of still-open ``{`` / ``[`` (in order) if the scan ends **outside**
+      a string and no structural mismatch occurred.
+    - Returns ``None`` if a closer has no opener, brace/bracket types mismatch, or the
+      scan ends **inside** an unterminated string (unsafe to append synthetic closers).
+
+    **State sketch** (``O`` = outside string, ``I`` = inside ``"..."``)::
+
+        O -- '"' ------------------------> I
+        O -- '{' '[' --------------------> push on stack (stay O)
+        O -- '}' ']' --------------------> pop; empty/mismatch -> None
+        I -- '\\' -----------------------> next char skipped (escaped)
+        I -- '"' (not after '\\') ------> O
+        I -- other ----------------------> stay I
+
+    **Edge cases:** ``]`` / ``}`` inside a string do not touch the stack. Truncation
+    mid-string leaves ``I`` at EOF -> ``None`` (caller must not append closers).
+
+    **Examples:**
+
+    - ``{"a":1`` → ``["{"]`` (truncated object; caller may append ``}``).
+    - ``{"a":1}`` → ``[]`` (balanced).
+    - ``{]`` → ``None`` (malformed; do not balance).
+    - ``{"x":"`` → ``None`` (truncated inside string).
+    """
+    stack: List[str] = []
+    in_string = False
+    escaped = False
+    for ch in candidate:
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if ch == '"':
+                in_string = False
+            continue
+
+        if ch == '"':
+            in_string = True
+            escaped = False
+            continue
+        if ch in "{[":
+            stack.append(ch)
+            continue
+        if ch in "}]":
+            if not stack:
+                return None
+            top = stack[-1]
+            if ch == "}" and top != "{":
+                return None
+            if ch == "]" and top != "[":
+                return None
+            stack.pop()
+            continue
+
+    return None if in_string else stack
+
+
+def _comma_is_trailing_before_close(candidate: str, comma_index: int) -> bool:
+    """True if ``candidate[comma_index]`` is a comma followed only by whitespace then ``}`` or ``]``."""
+    j = comma_index + 1
+    while j < len(candidate) and candidate[j].isspace():
+        j += 1
+    return j < len(candidate) and candidate[j] in "}]"
+
+
+def strip_trailing_commas_outside_strings(candidate: str) -> str:
+    """
+    Remove a comma immediately before ``}`` or ``]`` when outside double-quoted strings.
+
+    Same string/escape assumptions as delimiter scanning in this module.
+    Does not rewrite commas inside strings; if string state is wrong, behavior is undefined.
+    """
+    out: List[str] = []
+    in_string = False
+    escaped = False
+    i = 0
+    while i < len(candidate):
+        char = candidate[i]
+        if escaped:
+            out.append(char)
+            escaped = False
+            i += 1
+            continue
+        if char == "\\" and in_string:
+            out.append(char)
+            escaped = True
+            i += 1
+            continue
+        if char == '"':
+            out.append(char)
+            in_string = not in_string
+            i += 1
+            continue
+        if not in_string and char == "," and _comma_is_trailing_before_close(candidate, i):
+            # Drop this comma: JSON disallows it; LLMs often emit one before ``}``.
+            i += 1
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _consume_backslash_inside_json_string(
+    s: str, i: int, n: int, out: List[str]
+) -> int:
+    """
+    Handle ``\\`` at index ``i`` **inside** a JSON string (caller ensures ``in_string``).
+
+    **Pre:** ``0 <= i < n`` and ``s[i] == "\\"``.
+
+    **Post:** Appends the corrected escape sequence fragment to ``out`` and returns the
+    new read index (always ``> i``).
+
+    **Examples:**
+
+    - ``...\\n...`` at ``i`` → append ``\\n``, return ``i + 2``.
+    - ``...\\\\...`` → append ``\\\\`` (one JSON escaped backslash), return ``i + 2``.
+    - ``...\\x...`` (invalid) → append ``\\\\`` only; return ``i + 1`` so ``x`` is copied
+      as a normal character on the next loop (literal ``x`` in the string value).
+    - trailing ``\\`` at end of buffer → append ``\\\\`` (literal backslash), return ``n``.
+    """
+    if i + 1 >= n:
+        out.append("\\\\")
+        return n
+    nxt = s[i + 1]
+    if nxt == "\\":
+        out.append("\\\\")
+        return i + 2
+    if _is_simple_json_escape_char(nxt):
+        out.extend(("\\", nxt))
+        return i + 2
+    if _is_unicode_escape_at(s, i):
+        out.append(s[i : i + 6])
+        return i + 6
+    # Invalid escape (e.g. ``\x``, ``\'``): JSON rejects ``\`` + unknown; double the
+    # backslash so the following character is read as literal content.
+    out.append("\\\\")
+    return i + 1
+
+
+def fix_invalid_json_string_escapes(s: str) -> str:
+    """
+    Escape backslashes that start invalid JSON escape sequences inside double-quoted strings.
+
+    JSON allows only \\\", \\\\, \\/, \\b, \\f, \\n, \\r, \\t, \\uXXXX. Sequences like \\x or \\'
+    break parsing; doubling the backslash preserves intent (literal backslash + next char).
+
+    Backslash handling is delegated to ``_consume_backslash_inside_json_string`` so each
+    ``\\`` is resolved in one step (valid escape, ``\\\\``, ``\\uXXXX``, or invalid prefix).
+
+    **State sketch** (structural ``"`` toggles only; braces outside strings are copied)::
+
+        O (outside) -- '"' ------------> I (inside string value)
+        O -- any other char -----------> copy (structure pass-through)
+        I -- '"' ----------------------> O   (end of string token)
+        I -- '\\' --------------------> emit via _consume_*; advance index
+        I -- plain char --------------> copy
+
+    **Invariant:** Outside strings the buffer is copied verbatim so keys/braces stay
+    aligned. Inside strings, only ``\\`` sequences are rewritten. If the scan is already
+    mis-synchronized (e.g. an odd ``"`` in a code snippet), output may be wrong.
+    """
+    out: List[str] = []
+    i = 0
+    n = len(s)
+    in_string = False
+    while i < n:
+        ch = s[i]
+        if not in_string:
+            if ch == '"':
+                in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            in_string = False
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "\\":
+            i = _consume_backslash_inside_json_string(s, i, n, out)
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)

--- a/oasis/templates/dashboard.html
+++ b/oasis/templates/dashboard.html
@@ -9,6 +9,10 @@
     // Pre-loading model emojis from Python
     const modelEmojis = {{ model_emojis|tojson|safe }};
     const vulnEmojis = {{ vuln_emojis|tojson|safe }};
+    // Single source of truth for allowed formats and UI ordering (see REPORT in config.py)
+    window.__OASIS_DASHBOARD__ = window.__OASIS_DASHBOARD__ || {};
+    window.__OASIS_DASHBOARD__.outputFormats = {{ report_output_formats|tojson|safe }};
+    window.__OASIS_DASHBOARD__.formatDisplayOrder = {{ dashboard_format_display_order|tojson|safe }};
 </script>
 {% endblock %}
 

--- a/oasis/templates/report_styles.css
+++ b/oasis/templates/report_styles.css
@@ -170,6 +170,21 @@ h3 {
     margin-top: 1em;
 }
 
+h4 {
+    color: var(--dark-blue);
+    font-size: 12pt;
+    margin-top: 0.9em;
+    margin-bottom: 0.4em;
+}
+
+h5 {
+    color: var(--dark-blue);
+    font-size: 11pt;
+    margin-top: 0.8em;
+    margin-bottom: 0.3em;
+    font-weight: 600;
+}
+
 p {
     margin: 0.7em 0;
 }
@@ -226,4 +241,14 @@ tr:nth-child(even) {
     padding: 15px;
     margin: 1em 0;
     box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.report-file-block {
+    background-color: white;
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--turquoise);
+    border-radius: 6px;
+    padding: 14px 16px;
+    margin: 14px 0 18px 0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }

--- a/oasis/templates/reports/_macros.html.j2
+++ b/oasis/templates/reports/_macros.html.j2
@@ -39,6 +39,12 @@
 </table>
 {%- endmacro %}
 
+{% macro render_chunk_source_lines(chunk) -%}
+{% if chunk.start_line is not none and chunk.end_line is not none %}
+<p class="chunk-source-lines"><strong>Source lines:</strong> {{ chunk.start_line }}&ndash;{{ chunk.end_line }}</p>
+{% endif %}
+{%- endmacro %}
+
 {% macro render_chunk_notes(chunk, file_index, chunk_index) -%}
 <h4>Chunk {{ file_index }}.{{ chunk_index }} notes</h4>
 <pre>{{ chunk.notes }}</pre>

--- a/oasis/templates/reports/_macros.html.j2
+++ b/oasis/templates/reports/_macros.html.j2
@@ -1,0 +1,77 @@
+{% macro render_header(document) -%}
+<h1>{{ document.title }}</h1>
+<p><strong>Date:</strong> {{ document.generated_at }} &mdash; <strong>Model:</strong> {{ document.model_name }}</p>
+<p><strong>Vulnerability:</strong> {{ document.vulnerability_name }}</p>
+{%- endmacro %}
+
+{% macro render_table_of_contents() -%}
+<h2 id="table-of-contents">Table of contents</h2>
+<ol>
+  <li><a href="#summary">Summary</a></li>
+  <li><a href="#statistics">Statistics</a></li>
+  <li><a href="#files">Files</a></li>
+  <li><a href="#detailed-analysis">Detailed analysis</a></li>
+  <li><a href="#errors-notes">Errors &amp; Notes</a></li>
+</ol>
+{%- endmacro %}
+
+{% macro render_statistics(stats) -%}
+<h2 id="statistics">Statistics</h2>
+<ul>
+  <li><strong>Files analyzed:</strong> {{ stats.files_analyzed }}</li>
+  <li><strong>Total findings:</strong> {{ stats.total_findings }}</li>
+  <li><strong>Critical:</strong> {{ stats.critical_risk }}</li>
+  <li><strong>High:</strong> {{ stats.high_risk }}</li>
+  <li><strong>Medium:</strong> {{ stats.medium_risk }}</li>
+  <li><strong>Low:</strong> {{ stats.low_risk }}</li>
+</ul>
+{%- endmacro %}
+
+{% macro render_file_summary(files) -%}
+<h2 id="files">Files</h2>
+<table class="summary-table">
+  <thead><tr><th>File</th><th>Similarity</th></tr></thead>
+  <tbody>
+  {% for file in files %}
+    <tr><td><code>{{ file.file_path }}</code></td><td>{{ "%.3f"|format(file.similarity_score) }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{%- endmacro %}
+
+{% macro render_chunk_notes(chunk, file_index, chunk_index) -%}
+<h4>Chunk {{ file_index }}.{{ chunk_index }} notes</h4>
+<pre>{{ chunk.notes }}</pre>
+{%- endmacro %}
+
+{% macro render_finding(finding, file_index, finding_index) -%}
+<h4>Finding {{ file_index }}.{{ finding_index }}: {{ finding.title }} <span class="severity">({{ finding.severity }})</span></h4>
+{% if finding.vulnerable_code %}
+<h5>Vulnerable code</h5>
+<pre><code>{{ finding.vulnerable_code }}</code></pre>
+{% endif %}
+<h5>Explanation</h5>
+<p>{{ finding.explanation }}</p>
+{% if finding.impact %}<h5>Impact</h5><p>{{ finding.impact }}</p>{% endif %}
+{% if finding.entry_point %}<h5>Entry point</h5><p>{{ finding.entry_point }}</p>{% endif %}
+{% if finding.execution_path_diagram %}
+<h5>Execution path</h5>
+<pre><code>{{ finding.execution_path_diagram }}</code></pre>
+{% endif %}
+{% if finding.http_methods %}<h5>HTTP methods</h5><p>{{ finding.http_methods | join(', ') }}</p>{% endif %}
+{% if finding.manipulable_parameters %}<h5>Parameters</h5><p>{{ finding.manipulable_parameters | join(', ') }}</p>{% endif %}
+{% if finding.exploitation_steps %}
+<h5>Exploitation steps</h5>
+<ul>{% for step in finding.exploitation_steps %}<li>{{ step }}</li>{% endfor %}</ul>
+{% endif %}
+{% if finding.example_payloads %}
+<h5>Example payloads</h5>
+<ul>{% for payload in finding.example_payloads %}<li><code>{{ payload }}</code></li>{% endfor %}</ul>
+{% endif %}
+{% if finding.exploitation_conditions %}<h5>Conditions</h5><p>{{ finding.exploitation_conditions }}</p>{% endif %}
+{% if finding.remediation %}<h5>Remediation</h5><p>{{ finding.remediation }}</p>{% endif %}
+{% if finding.secure_code_example %}
+<h5>Secure example</h5>
+<pre><code>{{ finding.secure_code_example }}</code></pre>
+{% endif %}
+{%- endmacro %}

--- a/oasis/templates/reports/_macros.md.j2
+++ b/oasis/templates/reports/_macros.md.j2
@@ -1,0 +1,119 @@
+{% macro render_header(document) -%}
+# {{ document.title }}
+
+Date: {{ document.generated_at }}  
+Model: {{ document.model_name }}  
+Vulnerability: {{ document.vulnerability_name }}
+{%- endmacro %}
+
+{% macro render_table_of_contents() -%}
+## Table of contents
+
+1. [Summary](#summary)
+2. [Statistics](#statistics)
+3. [Files](#files)
+4. [Detailed Analysis](#detailed-analysis)
+5. [Errors & Notes](#errors--notes)
+{%- endmacro %}
+
+{% macro render_statistics(stats) -%}
+## Statistics
+
+- Files analyzed: {{ stats.files_analyzed }}
+- Total findings: {{ stats.total_findings }}
+- Critical: {{ stats.critical_risk }}
+- High: {{ stats.high_risk }}
+- Medium: {{ stats.medium_risk }}
+- Low: {{ stats.low_risk }}
+{%- endmacro %}
+
+{% macro render_file_summary(files) -%}
+## Files
+
+| File | Similarity |
+|------|------------|
+{% for file in files -%}
+| `{{ file.file_path }}` | {{ "%.3f"|format(file.similarity_score) }} |
+{% endfor %}
+{%- endmacro %}
+
+{% macro render_chunk_notes(chunk, file_index, chunk_index) -%}
+#### Chunk {{ file_index }}.{{ chunk_index }} Notes
+
+{{ chunk.notes }}
+{%- endmacro %}
+
+{% macro render_finding(finding, file_index, finding_index) -%}
+#### Finding {{ file_index }}.{{ finding_index }}: {{ finding.title }} ({{ finding.severity }})
+
+{% if finding.vulnerable_code %}
+##### Vulnerable Code
+
+```text
+{{ finding.vulnerable_code }}
+```
+{% endif %}
+
+##### Explanation
+
+{{ finding.explanation }}
+
+{% if finding.impact %}
+##### Impact
+
+{{ finding.impact }}
+{% endif %}
+{% if finding.entry_point %}
+##### Entry Point
+
+{{ finding.entry_point }}
+{% endif %}
+{% if finding.execution_path_diagram %}
+##### Execution Path
+
+```text
+{{ finding.execution_path_diagram }}
+```
+{% endif %}
+{% if finding.http_methods %}
+##### HTTP Methods
+
+{{ finding.http_methods | join(", ") }}
+{% endif %}
+{% if finding.manipulable_parameters %}
+##### Parameters
+
+{{ finding.manipulable_parameters | join(", ") }}
+{% endif %}
+{% if finding.exploitation_steps %}
+##### Exploitation Steps
+
+{% for step in finding.exploitation_steps %}
+- {{ step }}
+{% endfor %}
+{% endif %}
+{% if finding.example_payloads %}
+##### Example Payloads
+
+{% for payload in finding.example_payloads %}
+- `{{ payload }}`
+{% endfor %}
+{% endif %}
+{% if finding.exploitation_conditions %}
+##### Conditions
+
+{{ finding.exploitation_conditions }}
+{% endif %}
+{% if finding.remediation %}
+##### Remediation
+
+{{ finding.remediation }}
+{% endif %}
+{% if finding.secure_code_example %}
+##### Secure Example
+
+```text
+{{ finding.secure_code_example }}
+```
+{% endif %}
+{%- endmacro %}

--- a/oasis/templates/reports/_macros.md.j2
+++ b/oasis/templates/reports/_macros.md.j2
@@ -37,6 +37,12 @@ Vulnerability: {{ document.vulnerability_name }}
 {% endfor %}
 {%- endmacro %}
 
+{% macro render_chunk_source_lines(chunk) -%}
+{% if chunk.start_line is not none and chunk.end_line is not none %}
+_Source lines {{ chunk.start_line }}-{{ chunk.end_line }} (1-based, inclusive)._
+{% endif %}
+{%- endmacro %}
+
 {% macro render_chunk_notes(chunk, file_index, chunk_index) -%}
 #### Chunk {{ file_index }}.{{ chunk_index }} Notes
 

--- a/oasis/templates/reports/vulnerability_export.md.j2
+++ b/oasis/templates/reports/vulnerability_export.md.j2
@@ -1,0 +1,53 @@
+{% import "reports/_macros.md.j2" as macros %}
+
+{{ macros.render_header(document) }}
+
+## Summary
+
+Analyzed {{ document.files|length }} file(s) for {{ document.vulnerability_name }}.
+
+{{ macros.render_table_of_contents() }}
+
+{{ macros.render_statistics(document.stats) }}
+
+{{ macros.render_file_summary(document.files) }}
+
+## Detailed Analysis
+
+{% for f in document.files %}
+---
+
+### File {{ loop.index }}: {{ f.file_path }}
+{% set file_index = loop.index %}
+
+- Similarity score: {{ "%.3f"|format(f.similarity_score) }}
+
+{% if f.error %}
+#### File Error
+
+{{ f.error }}
+{% endif %}
+
+{% for chunk in f.chunk_analyses %}
+{% set chunk_index = loop.index %}
+{% if chunk.notes and not chunk.findings %}
+{{ macros.render_chunk_notes(chunk, file_index, chunk_index) }}
+{% endif %}
+{% for finding in chunk.findings %}
+{{ macros.render_finding(finding, file_index, loop.index) }}
+
+{% endfor %}
+{% endfor %}
+{% endfor %}
+
+## Errors & Notes
+
+{% if document.files | selectattr("error") | list %}
+### Files With Errors
+
+{% for f in document.files if f.error %}
+- `{{ f.file_path }}`: {{ f.error }}
+{% endfor %}
+{% else %}
+No file-level errors were recorded.
+{% endif %}

--- a/oasis/templates/reports/vulnerability_export.md.j2
+++ b/oasis/templates/reports/vulnerability_export.md.j2
@@ -30,6 +30,7 @@ Analyzed {{ document.files|length }} file(s) for {{ document.vulnerability_name 
 
 {% for chunk in f.chunk_analyses %}
 {% set chunk_index = loop.index %}
+{{ macros.render_chunk_source_lines(chunk) }}
 {% if chunk.notes and not chunk.findings %}
 {{ macros.render_chunk_notes(chunk, file_index, chunk_index) }}
 {% endif %}

--- a/oasis/templates/reports/vulnerability_from_json.html.j2
+++ b/oasis/templates/reports/vulnerability_from_json.html.j2
@@ -1,0 +1,52 @@
+{% import "reports/_macros.html.j2" as macros %}
+
+{{ macros.render_header(document) }}
+
+<h2 id="summary">Summary</h2>
+<p>Analyzed <strong>{{ document.files|length }}</strong> file(s) for {{ document.vulnerability_name }}.</p>
+
+{{ macros.render_table_of_contents() }}
+
+{{ macros.render_statistics(document.stats) }}
+
+{{ macros.render_file_summary(document.files) }}
+
+<div class="page-break"></div>
+
+<h2 id="detailed-analysis">Detailed analysis</h2>
+{% for f in document.files %}
+  {% if not loop.first %}<div class="page-break"></div>{% endif %}
+  <section class="report-file-block">
+    <h3 id="file-{{ loop.index }}">File {{ loop.index }}: {{ f.file_path }}</h3>
+    {% set file_index = loop.index %}
+    <p><strong>Similarity score:</strong> {{ "%.3f"|format(f.similarity_score) }}</p>
+    {% if f.error %}
+      <h4>File error</h4>
+      <p class="error">{{ f.error }}</p>
+    {% endif %}
+    {% for chunk in f.chunk_analyses %}
+      {% set chunk_index = loop.index %}
+      {% if chunk.notes and not chunk.findings %}
+        {{ macros.render_chunk_notes(chunk, file_index, chunk_index) }}
+      {% endif %}
+      {% for finding in chunk.findings %}
+        {{ macros.render_finding(finding, file_index, loop.index) }}
+      {% endfor %}
+    {% endfor %}
+  </section>
+{% endfor %}
+
+<div class="page-break"></div>
+
+<h2 id="errors-notes">Errors &amp; Notes</h2>
+{% set error_files = document.files | selectattr("error") | list %}
+{% if error_files %}
+  <h3>Files with errors</h3>
+  <ul>
+  {% for file in error_files %}
+    <li><code>{{ file.file_path }}</code>: {{ file.error }}</li>
+  {% endfor %}
+  </ul>
+{% else %}
+  <p>No file-level errors were recorded.</p>
+{% endif %}

--- a/oasis/templates/reports/vulnerability_from_json.html.j2
+++ b/oasis/templates/reports/vulnerability_from_json.html.j2
@@ -26,6 +26,7 @@
     {% endif %}
     {% for chunk in f.chunk_analyses %}
       {% set chunk_index = loop.index %}
+      {{ macros.render_chunk_source_lines(chunk) }}
       {% if chunk.notes and not chunk.findings %}
         {{ macros.render_chunk_notes(chunk, file_index, chunk_index) }}
       {% endif %}

--- a/oasis/tools.py
+++ b/oasis/tools.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import re
 import sys
 import numpy as np
-from typing import List, Dict
+from typing import Dict, List, Optional, Tuple
 from weasyprint.logger import LOGGER as weasyprint_logger
 
 # Import configuration
@@ -178,6 +178,72 @@ def setup_logging(debug=False, silent=False, error_log_file=None):
     logging.getLogger('PIL').setLevel(logging.WARNING)
     logging.getLogger('markdown').setLevel(logging.WARNING)
 
+def chunk_content_with_spans(content: str, max_length: int = 2048) -> List[Tuple[str, int, int]]:
+    """
+    Split content into chunks with 1-based inclusive (start_line, end_line) per chunk.
+
+    Line boundaries follow ``str.splitlines()`` (same as ``chunk_content``). Empty
+    content yields no chunks (empty list).
+
+    When a logical line cannot fit under the internal budget ``len(line) + 1`` (the
+    ``+1`` stands for a newline when joining lines), that line is split into
+    consecutive substrings of at most ``max_length`` characters each; every such
+    piece keeps the same ``(start_line, end_line)`` as the source line.
+    """
+    if max_length < 1:
+        max_length = 1
+
+    if not content:
+        return []
+
+    lines = content.splitlines()
+
+    def line_exceeds_join_budget(line: str) -> bool:
+        return len(line) + 1 > max_length
+
+    def append_split_line(line: str, line_no: int) -> None:
+        for i in range(0, len(line), max_length):
+            out.append((line[i : i + max_length], line_no, line_no))
+
+    out: List[Tuple[str, int, int]] = []
+    current_chunk: List[str] = []
+    current_length = 0
+    chunk_start_line: Optional[int] = None
+
+    for line_no, line in enumerate(lines, start=1):
+        line_length = len(line) + 1  # +1 for newline
+        if current_length + line_length > max_length:
+            if current_chunk:
+                assert chunk_start_line is not None
+                text = "\n".join(current_chunk)
+                end_ln = chunk_start_line + len(current_chunk) - 1
+                out.append((text, chunk_start_line, end_ln))
+                current_chunk = []
+                current_length = 0
+                chunk_start_line = None
+            if line_exceeds_join_budget(line):
+                append_split_line(line, line_no)
+            else:
+                chunk_start_line = line_no
+                current_chunk = [line]
+                current_length = line_length
+        else:
+            if not current_chunk:
+                chunk_start_line = line_no
+            current_chunk.append(line)
+            current_length += line_length
+
+    if current_chunk:
+        assert chunk_start_line is not None
+        text = "\n".join(current_chunk)
+        end_ln = chunk_start_line + len(current_chunk) - 1
+        out.append((text, chunk_start_line, end_ln))
+
+    logger.debug(f"Split content of {len(content)} chars into {len(out)} chunks (with line spans)")
+
+    return out
+
+
 def chunk_content(content: str, max_length: int = 2048) -> List[str]:
     """
     Split content into chunks of maximum length while preserving line integrity
@@ -188,31 +254,7 @@ def chunk_content(content: str, max_length: int = 2048) -> List[str]:
     Returns:
         List of content chunks
     """
-    if len(content) <= max_length:
-        return [content]
-
-    chunks = []
-    lines = content.splitlines()
-    current_chunk = []
-    current_length = 0
-
-    for line in lines:
-        line_length = len(line) + 1  # +1 for newline
-        if current_length + line_length > max_length:
-            if current_chunk:
-                chunks.append('\n'.join(current_chunk))
-            current_chunk = [line]
-            current_length = line_length
-        else:
-            current_chunk.append(line)
-            current_length += line_length
-
-    if current_chunk:
-        chunks.append('\n'.join(current_chunk))
-
-    logger.debug(f"Split content of {len(content)} chars into {len(chunks)} chunks")
-
-    return chunks
+    return [t[0] for t in chunk_content_with_spans(content, max_length)]
 
 def extract_clean_path(input_path: str | Path) -> Path:
     """

--- a/oasis/tools.py
+++ b/oasis/tools.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import logging
 from pathlib import Path
 import re
+import sys
 import numpy as np
 from typing import List, Dict
 from weasyprint.logger import LOGGER as weasyprint_logger
@@ -116,27 +117,43 @@ def setup_logging(debug=False, silent=False, error_log_file=None):
     # Set root logger level
     root_logger = logging.getLogger()
 
-    # Avoid adding duplicate handlers if they already exist.
-    if root_logger.handlers:
-        return
-
     if debug:
         root_logger.setLevel(logging.DEBUG)
     else:
         root_logger.setLevel(logging.INFO)
 
     # Configure handlers based on silent mode
-    if not silent:
+    has_console_handler = any(
+        isinstance(handler, logging.StreamHandler)
+        and getattr(handler, "stream", None) is sys.stderr
+        for handler in logger.handlers
+    )
+    if not silent and not has_console_handler:
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(EmojiFormatter())
         logger.addHandler(console_handler)
 
-    # Add file handler for errors in silent mode
-    if silent and error_log_file:
-        file_handler = logging.FileHandler(error_log_file)
+    # Replace existing error file handler when a new path is provided.
+    existing_error_file_handlers = [
+        handler
+        for handler in logger.handlers
+        if getattr(handler, "_oasis_handler_name", "") == "error_file"
+    ]
+    for handler in existing_error_file_handlers:
+        logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+
+    if error_log_file:
+        error_log_file = Path(error_log_file)
+        error_log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(error_log_file, encoding="utf-8")
         file_handler.setLevel(logging.ERROR)  # Only log errors and above
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
         file_handler.setFormatter(formatter)
+        file_handler._oasis_handler_name = "error_file"
         logger.addHandler(file_handler)
 
     logger.propagate = False  # Prevent duplicate logging

--- a/oasis/web.py
+++ b/oasis/web.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+import logging
+import json
 from pathlib import Path
 import re
 import secrets
@@ -11,6 +13,8 @@ from functools import wraps
 from .config import VULNERABILITY_MAPPING, MODEL_EMOJIS, VULN_EMOJIS
 from .report import Report
 from .tools import parse_iso_date, parse_report_date
+
+logger = logging.getLogger(__name__)
 
 class WebServer:
     def __init__(self, report, debug=False, web_expose='local', web_password=None, web_port=5000):
@@ -100,6 +104,28 @@ class WebServer:
         """Render the login template"""
         return render_template('login.html', error=error)
 
+    def _is_within_security_root(self, path: Path, root: Path) -> bool:
+        """Compatibility-safe path containment check (Python 3.9+ and older)."""
+        is_relative_to = getattr(path, "is_relative_to", None)
+        if callable(is_relative_to):
+            return path.is_relative_to(root)
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            return False
+
+    def _report_preview_error_response(self, logger_message: str):
+        logger.exception(logger_message)
+        return (
+            jsonify(
+                {
+                    'error': 'Failed to generate report preview. Please contact support if the problem persists.'
+                }
+            ),
+            500,
+        )
+
     def register_routes(self, app, server, login_required):
         # Logout route
         @app.route('/logout', methods=['GET'])
@@ -126,9 +152,11 @@ class WebServer:
             vuln_filter = request.args.get('vulnerability', '')
             start_date = request.args.get('start_date', None)
             end_date = request.args.get('end_date', None)
-            # New parameter to show only MD reports for dates (default to True)
             md_dates_only = request.args.get('md_dates_only', '1') == '1'
-            
+
+            if request.args.get('force', '0') == '1':
+                self.collect_report_data()
+
             # Filter reports based on parameters
             filtered_data = self.filter_reports(
                 model_filter, 
@@ -174,15 +202,94 @@ class WebServer:
         @app.route('/api/report-content/<path:filename>')
         @login_required
         def get_report_content(filename):
-            # Return content of markdown file for previewing
+            # Legacy markdown preview only when no canonical JSON exists for the same stem.
+            try:
+                allow_canonical_json_preview = request.args.get('allow_canonical_json_preview', '0') == '1'
+                file_path = self.security_dir / filename
+                security_root = self.security_dir.resolve()
+                resolved_path = file_path.resolve(strict=False)
+
+                if not self._is_within_security_root(resolved_path, security_root):
+                    return jsonify({'error': 'Invalid path'}), 403
+
+                if not resolved_path.exists() or resolved_path.suffix != '.md':
+                    return jsonify({'error': 'File not found or not a markdown file'}), 404
+
+                rel_path = resolved_path.relative_to(security_root)
+                rel_parts = rel_path.parts
+                if len(rel_parts) < 2:
+                    return jsonify({'error': 'Invalid report path'}), 400
+
+                json_rel_path = Path("json", *rel_parts[1:]).with_suffix(".json")
+                json_path = security_root / json_rel_path
+                if json_path.exists() and not allow_canonical_json_preview:
+                    return (
+                        jsonify(
+                            {
+                                'error': 'Canonical report is JSON; use JSON preview endpoint.',
+                            }
+                        ),
+                        409,
+                    )
+                html_content = self.report.read_and_convert_markdown(resolved_path)
+                return jsonify({'content': html_content})
+            except Exception:
+                return self._report_preview_error_response("Error while generating markdown report preview")
+
+        @app.route('/api/report-json/<path:filename>')
+        @login_required
+        def get_report_json(filename):
             try:
                 file_path = self.security_dir / filename
-                if file_path.exists() and file_path.suffix == '.md':
-                    html_content = self.report.read_and_convert_markdown(file_path)
-                    return jsonify({'content': html_content})
-                return jsonify({'error': 'File not found or not a markdown file'}), 404
-            except Exception as e:
-                return jsonify({'error': str(e)}), 500
+                security_root = self.security_dir.resolve()
+                resolved_path = file_path.resolve(strict=False)
+
+                if not self._is_within_security_root(resolved_path, security_root):
+                    return jsonify({'error': 'Invalid path'}), 403
+                if not resolved_path.exists() or resolved_path.suffix != '.json':
+                    return jsonify({'error': 'File not found or not JSON'}), 404
+                with open(resolved_path, 'r', encoding='utf-8') as f:
+                    payload = json.load(f)
+                if not isinstance(payload, dict):
+                    return jsonify({'error': 'Invalid JSON report payload'}), 422
+                return jsonify(payload)
+            except Exception:
+                return self._report_preview_error_response("Error while generating JSON report preview")
+
+        def _load_report_html_from_json_path(filename: str):
+            try:
+                file_path = self.security_dir / filename
+                security_root = self.security_dir.resolve()
+                resolved_path = file_path.resolve(strict=False)
+
+                if not self._is_within_security_root(resolved_path, security_root):
+                    return jsonify({'error': 'Invalid path'}), 403
+                if not resolved_path.exists() or resolved_path.suffix != '.json':
+                    return jsonify({'error': 'File not found or not JSON'}), 404
+
+                with open(resolved_path, 'r', encoding='utf-8') as f:
+                    payload = json.load(f)
+                if not isinstance(payload, dict):
+                    return jsonify({'error': 'Invalid JSON report payload'}), 422
+
+                html_content = self.report.render_report_html_from_json_payload(payload)
+                return jsonify({'content': html_content}), 200
+            except Exception:
+                return self._report_preview_error_response("Error while generating HTML preview from canonical JSON report")
+
+        @app.route('/api/report-html')
+        @login_required
+        def get_report_html_query():
+            filename = request.args.get('path', '')
+            if not filename:
+                return jsonify({'error': 'No path provided'}), 400
+            return _load_report_html_from_json_path(filename)
+
+        @app.route('/api/report-html/<path:filename>')
+        @login_required
+        def get_report_html(filename):
+            # Backward-compatible route for previous clients.
+            return _load_report_html_from_json_path(filename)
 
         @app.route('/api/download')
         @login_required
@@ -211,7 +318,8 @@ class WebServer:
                 content_types = {
                     '.md': 'text/markdown',
                     '.html': 'text/html',
-                    '.pdf': 'application/pdf'
+                    '.pdf': 'application/pdf',
+                    '.json': 'application/json',
                 }
                 content_type = content_types.get(abs_path.suffix, 'application/octet-stream')
                 
@@ -253,10 +361,17 @@ class WebServer:
                     # Create a dictionary date_info from the date string
                     date_info = {'date': report['date']}
                     
-                    # Add the path of the MD file if available
-                    if report.get('alternative_formats', {}).get('md'):
-                        date_info['path'] = report['alternative_formats']['md']
-                    
+                    af = report.get('alternative_formats', {})
+                    if af.get('json'):
+                        date_info['path'] = af['json']
+                        date_info['format'] = 'json'
+                    elif af.get('md'):
+                        date_info['path'] = af['md']
+                        date_info['format'] = 'md'
+                    elif report.get('path'):
+                        date_info['path'] = report['path']
+                        date_info['format'] = report.get('format', 'md')
+
                     dates.append(date_info)
             
             # Sort dates from newest to oldest
@@ -271,6 +386,29 @@ class WebServer:
         reports = self._collect_reports_from_directories()
         self.report_data = reports
         self.global_stats = self._calculate_global_statistics(reports)
+
+    @staticmethod
+    def _stats_from_json_report_file(report_file: Path) -> dict:
+        """Load dashboard stats from a canonical vulnerability JSON report."""
+        try:
+            with open(report_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            st = data.get('stats') or {}
+            return {
+                'files_analyzed': int(st.get('files_analyzed', 0)),
+                'high_risk': int(st.get('high_risk', 0)),
+                'medium_risk': int(st.get('medium_risk', 0)),
+                'low_risk': int(st.get('low_risk', 0)),
+                'critical_risk': int(st.get('critical_risk', 0)),
+                'total_findings': int(st.get('total_findings', 0)),
+            }
+        except Exception as exc:
+            logger.warning(
+                "Failed to load stats from JSON report '%s': %s",
+                report_file,
+                exc,
+            )
+            return {}
         
     def _collect_reports_from_directories(self):
         """Extract reports data from directory structure"""
@@ -301,10 +439,10 @@ class WebServer:
             fmt = fmt_dir.name
 
             # Check if it's a valid format
-            if fmt not in ['md', 'html', 'pdf']:
+            if fmt not in ['json', 'md', 'html', 'pdf']:
                 continue
 
-            # Explore report files
+            globber = fmt_dir.glob('*.json') if fmt == 'json' else fmt_dir.glob('*.*')
             model_reports.extend(
                 self._process_report_file(
                     report_file,
@@ -314,7 +452,7 @@ class WebServer:
                     timestamp_dir,
                     model_dir,
                 )
-                for report_file in fmt_dir.glob('*.*')
+                for report_file in globber
             )
         return model_reports
         
@@ -323,8 +461,7 @@ class WebServer:
         # Extract vulnerability type from filename
         vulnerability_type = self._extract_vulnerability_type(report_file.stem)
         
-        # Extract report stats if it's a markdown
-        stats = self._parse_vulnerability_statistics(report_file) if fmt == 'md' else {}
+        stats = self._stats_from_json_report_file(report_file) if fmt == 'json' else {}
         
         # Build relative path for web access
         relative_path = report_file.relative_to(self.security_dir)
@@ -353,9 +490,9 @@ class WebServer:
             "formats": {},
             "dates": {},
             "risk_summary": {
-                "high": sum(report.get("stats", {}).get("high_risk", 0) for report in reports if report["format"] == "md"),
-                "medium": sum(report.get("stats", {}).get("medium_risk", 0) for report in reports if report["format"] == "md"),
-                "low": sum(report.get("stats", {}).get("low_risk", 0) for report in reports if report["format"] == "md")
+                "high": sum(report.get("stats", {}).get("high_risk", 0) for report in reports if report["format"] == "json"),
+                "medium": sum(report.get("stats", {}).get("medium_risk", 0) for report in reports if report["format"] == "json"),
+                "low": sum(report.get("stats", {}).get("low_risk", 0) for report in reports if report["format"] == "json")
             }
         }
         
@@ -366,29 +503,25 @@ class WebServer:
         
     def _update_stats_from_report(self, stats, report):
         """Update statistics based on a single report"""
-        # Count only markdown files for accurate statistics
-        if report["format"] == "md":
+        if report["format"] == "json":
             stats["total_reports"] += 1
-            
-            # statistics by model
+
             model = report["model"]
             if model not in stats["models"]:
                 stats["models"][model] = 0
             stats["models"][model] += 1
-            
-            # statistics by vulnerability type
+
             vuln_type = report["vulnerability_type"]
             if vuln_type not in stats["vulnerabilities"]:
                 stats["vulnerabilities"][vuln_type] = 0
             stats["vulnerabilities"][vuln_type] += 1
-            
-            # statistics by date (only day)
+
             if report["date"]:
-                date_only = report["date"].split()[0]  # extract only the date part
+                date_only = report["date"].split()[0]
                 if date_only not in stats["dates"]:
                     stats["dates"][date_only] = 0
                 stats["dates"][date_only] += 1
-        
+
         # count all available formats
         fmt = report["format"]
         if fmt not in stats["formats"]:
@@ -419,7 +552,7 @@ class WebServer:
         """Find all available formats for a specific report"""
         formats = {}
         
-        for fmt in ['md', 'html', 'pdf']:
+        for fmt in ['json', 'md', 'html', 'pdf']:
             fmt_dir = model_dir / fmt
             if fmt_dir.exists() and fmt_dir.is_dir():
                 file_path = fmt_dir / f"{report_stem}.{fmt}"
@@ -457,42 +590,6 @@ class WebServer:
             filename,
         )
     
-    def _parse_vulnerability_statistics(self, report_file):
-        """
-        Parse vulnerability statistics from a report file
-        
-        Args:
-            report_file: Path to the report file to parse
-            
-        Returns:
-            Dictionary containing extracted statistics (files analyzed, risk levels, findings)
-        """
-        with open(report_file, 'r', encoding='utf-8') as f:
-            content = f.read()
-
-        # Extract metrics using regex patterns
-        stats = {}
-
-        if findings_match := re.search(r'Analyzed\s+(\d+)\s+files', content):
-            stats['files_analyzed'] = int(findings_match[1])
-
-        # Extract risk levels
-        high_risk = len(re.findall(r'High Risk Findings', content))
-        medium_risk = len(re.findall(r'Medium Risk Findings', content))
-        low_risk = len(re.findall(r'Low Risk Findings', content))
-
-        # Count table rows as an estimation of vulnerabilities
-        table_rows = len(re.findall(r'\|\s+\`[^\`]+\`\s+\|\s+[\d\.]+\s+\|', content))
-
-        stats |= {
-            'high_risk': high_risk,
-            'medium_risk': medium_risk,
-            'low_risk': low_risk,
-            'total_findings': table_rows,
-        }
-
-        return stats
-
     def _apply_date_filter(self, reports, start_date, end_date):
         """
         Apply date filtering to reports
@@ -521,6 +618,13 @@ class WebServer:
                                
         return filtered_reports
 
+    @staticmethod
+    def _is_date_visible_for_report(report: dict) -> bool:
+        """Return True when report date should be displayed in md_dates_only mode."""
+        has_json = bool(report.get("alternative_formats", {}).get("json"))
+        report_format = report.get("format")
+        return report_format == "json" or (report_format == "md" and not has_json)
+
     def filter_reports(self, model_filter='', format_filter='', vuln_filter='', start_date=None, end_date=None, md_dates_only=True):
         """Filter reports based on criteria"""
         if not self.report_data:
@@ -544,7 +648,7 @@ class WebServer:
 
             # For each report that isn't MD, mark date_visible=False
             for report in filtered:
-                report['date_visible'] = report['format'] == 'md'
+                report["date_visible"] = self._is_date_visible_for_report(report)
 
         else:
             # Standard branch - apply format and vulnerability filters
@@ -594,35 +698,30 @@ class WebServer:
         
         # Calculate statistics based on the provided reports
         for report in reports_to_analyze:
-            # Count only markdown files for accurate statistics
-            if report["format"] == "md":
+            if report["format"] == "json":
                 stats["total_reports"] += 1
-                
-                # statistics by model
+
                 model = report["model"]
                 if model not in stats["models"]:
                     stats["models"][model] = 0
                 stats["models"][model] += 1
-                
-                # statistics by vulnerability type
+
                 vuln_type = report["vulnerability_type"]
                 if vuln_type not in stats["vulnerabilities"]:
                     stats["vulnerabilities"][vuln_type] = 0
                 stats["vulnerabilities"][vuln_type] += 1
-                
-                # statistics by date (only day)
+
                 if report["date"]:
-                    date_only = report["date"].split()[0]  # extract only the date part
+                    date_only = report["date"].split()[0]
                     if date_only not in stats["dates"]:
                         stats["dates"][date_only] = 0
                     stats["dates"][date_only] += 1
-                
-                # Add risk summary if available
+
                 if "stats" in report and report["stats"]:
                     stats["risk_summary"]["high"] += report["stats"].get("high_risk", 0)
                     stats["risk_summary"]["medium"] += report["stats"].get("medium_risk", 0)
                     stats["risk_summary"]["low"] += report["stats"].get("low_risk", 0)
-            
+
             # count all available formats
             fmt = report["format"]
             if fmt not in stats["formats"]:

--- a/oasis/web.py
+++ b/oasis/web.py
@@ -10,11 +10,47 @@ from flask import Flask, render_template, request, jsonify, send_from_directory,
 from functools import wraps
 
 
-from .config import VULNERABILITY_MAPPING, MODEL_EMOJIS, VULN_EMOJIS
+from .config import REPORT, VULNERABILITY_MAPPING, MODEL_EMOJIS, VULN_EMOJIS
+from .export.filenames import artifact_filename, report_dir_glob_for_format
 from .report import Report
 from .tools import parse_iso_date, parse_report_date
 
 logger = logging.getLogger(__name__)
+
+
+def _dashboard_format_display_order() -> list[str]:
+    """Ordered formats for dashboard chips, date-picker open preference, and /api/dates.
+
+    Matching between DASHBOARD_FORMAT_DISPLAY_ORDER and OUTPUT_FORMATS is
+    case-insensitive, but the returned list preserves the original casing
+    from OUTPUT_FORMATS.
+    """
+    preferred = REPORT.get("DASHBOARD_FORMAT_DISPLAY_ORDER") or []
+    allowed = list(REPORT.get("OUTPUT_FORMATS") or [])
+
+    normalized_to_original: dict[str, str] = {}
+    for fmt in allowed:
+        key = fmt.lower()
+        if key not in normalized_to_original:
+            normalized_to_original[key] = fmt
+
+    seen_normalized: set[str] = set()
+    out: list[str] = []
+
+    for fmt in preferred:
+        key = fmt.lower()
+        original = normalized_to_original.get(key)
+        if original is not None and key not in seen_normalized:
+            out.append(original)
+            seen_normalized.add(key)
+
+    for fmt in allowed:
+        key = fmt.lower()
+        if key not in seen_normalized:
+            out.append(fmt)
+            seen_normalized.add(key)
+
+    return out
 
 class WebServer:
     def __init__(self, report, debug=False, web_expose='local', web_password=None, web_port=5000):
@@ -138,10 +174,14 @@ class WebServer:
         def dashboard():
             """Main dashboard page"""
             
-            return render_template('dashboard.html', 
-                                   model_emojis=MODEL_EMOJIS,
-                                   vuln_emojis=VULN_EMOJIS,
-                                   debug=self.debug)
+            return render_template(
+                'dashboard.html',
+                model_emojis=MODEL_EMOJIS,
+                vuln_emojis=VULN_EMOJIS,
+                debug=self.debug,
+                report_output_formats=REPORT.get('OUTPUT_FORMATS', []),
+                dashboard_format_display_order=_dashboard_format_display_order(),
+            )
             
         @app.route('/api/reports')
         @login_required
@@ -320,6 +360,7 @@ class WebServer:
                     '.html': 'text/html',
                     '.pdf': 'application/pdf',
                     '.json': 'application/json',
+                    '.sarif': 'application/sarif+json',
                 }
                 content_type = content_types.get(abs_path.suffix, 'application/octet-stream')
                 
@@ -362,12 +403,17 @@ class WebServer:
                     date_info = {'date': report['date']}
                     
                     af = report.get('alternative_formats', {})
-                    if af.get('json'):
-                        date_info['path'] = af['json']
-                        date_info['format'] = 'json'
-                    elif af.get('md'):
-                        date_info['path'] = af['md']
-                        date_info['format'] = 'md'
+                    open_path = None
+                    open_fmt = None
+                    # Prefer human-readable formats first (same order as dashboard)
+                    for fmt in _dashboard_format_display_order():
+                        if af.get(fmt):
+                            open_path = af[fmt]
+                            open_fmt = fmt
+                            break
+                    if open_path:
+                        date_info['path'] = open_path
+                        date_info['format'] = open_fmt
                     elif report.get('path'):
                         date_info['path'] = report['path']
                         date_info['format'] = report.get('format', 'md')
@@ -439,10 +485,10 @@ class WebServer:
             fmt = fmt_dir.name
 
             # Check if it's a valid format
-            if fmt not in ['json', 'md', 'html', 'pdf']:
+            if fmt not in REPORT["OUTPUT_FORMATS"]:
                 continue
 
-            globber = fmt_dir.glob('*.json') if fmt == 'json' else fmt_dir.glob('*.*')
+            globber = fmt_dir.glob(report_dir_glob_for_format(fmt))
             model_reports.extend(
                 self._process_report_file(
                     report_file,
@@ -506,27 +552,27 @@ class WebServer:
         if report["format"] == "json":
             stats["total_reports"] += 1
 
-            model = report["model"]
-            if model not in stats["models"]:
-                stats["models"][model] = 0
-            stats["models"][model] += 1
-
-            vuln_type = report["vulnerability_type"]
-            if vuln_type not in stats["vulnerabilities"]:
-                stats["vulnerabilities"][vuln_type] = 0
-            stats["vulnerabilities"][vuln_type] += 1
-
+            self._increment_stat_count(
+                report, "model", stats, "models"
+            )
+            self._increment_stat_count(
+                report, "vulnerability_type", stats, "vulnerabilities"
+            )
             if report["date"]:
                 date_only = report["date"].split()[0]
                 if date_only not in stats["dates"]:
                     stats["dates"][date_only] = 0
                 stats["dates"][date_only] += 1
 
-        # count all available formats
-        fmt = report["format"]
-        if fmt not in stats["formats"]:
-            stats["formats"][fmt] = 0
-        stats["formats"][fmt] += 1
+        self._increment_stat_count(
+            report, "format", stats, "formats"
+        )
+
+    def _increment_stat_count(self, report, arg1, stats, arg3):
+        model = report[arg1]
+        if model not in stats[arg3]:
+            stats[arg3][model] = 0
+        stats[arg3][model] += 1
 
     def _desanitize_name(self, sanitized_name):
         """Convert sanitized name back to display name"""
@@ -552,10 +598,10 @@ class WebServer:
         """Find all available formats for a specific report"""
         formats = {}
         
-        for fmt in ['json', 'md', 'html', 'pdf']:
+        for fmt in REPORT['OUTPUT_FORMATS']:
             fmt_dir = model_dir / fmt
             if fmt_dir.exists() and fmt_dir.is_dir():
-                file_path = fmt_dir / f"{report_stem}.{fmt}"
+                file_path = fmt_dir / artifact_filename(report_stem, fmt)
                 if file_path.exists():
                     # Include timestamp directory in the path
                     if timestamp_dir:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     { name = "psyray" }
 ]
 dependencies = [
+    "pydantic>=2.10.0",
     "ollama>=0.4.7",
     "weasyprint>=60.1",
     "markdown>=3.7",

--- a/tests/test_chunk_spans.py
+++ b/tests/test_chunk_spans.py
@@ -1,0 +1,90 @@
+"""Unit tests for line-aware chunk splitting (``chunk_content_with_spans``)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from oasis.tools import chunk_content, chunk_content_with_spans
+except ModuleNotFoundError:  # e.g. weasyprint not installed in minimal CI
+    chunk_content = None  # type: ignore[assignment]
+    chunk_content_with_spans = None  # type: ignore[assignment]
+
+
+@unittest.skipUnless(
+    chunk_content_with_spans is not None,
+    "oasis.tools import requires optional dependencies (e.g. weasyprint)",
+)
+class TestChunkContentWithSpans(unittest.TestCase):
+    def test_empty_content_yields_no_chunks(self):
+        self.assertEqual(chunk_content_with_spans("", 80), [])
+
+    def test_short_single_line(self):
+        self.assertEqual(chunk_content_with_spans("a", 10), [("a", 1, 1)])
+
+    def test_short_multiline_one_chunk(self):
+        text = "line1\nline2\nline3"
+        self.assertEqual(chunk_content_with_spans(text, 100), [(text, 1, 3)])
+
+    def test_matches_chunk_content_texts(self):
+        text = "alpha\nbeta\ngamma\ndelta"
+        max_len = 12
+        texts = [t[0] for t in chunk_content_with_spans(text, max_len)]
+        self.assertEqual(texts, chunk_content(text, max_len))
+
+    def test_shortcut_removed_join_budget_can_split_under_total_char_cap(self):
+        # Total len(content) == max_length, but per-line join budget forces two chunks.
+        text = "aaaaa\nbbbb"
+        self.assertEqual(len(text), 10)
+        spans = chunk_content_with_spans(text, 10)
+        self.assertEqual(len(spans), 2)
+        self.assertEqual(spans[0][0], "aaaaa")
+        self.assertEqual(spans[0][1:], (1, 1))
+        self.assertEqual(spans[1][0], "bbbb")
+        self.assertEqual(spans[1][1:], (2, 2))
+
+    def test_split_preserves_inclusive_line_ranges(self):
+        # Each line is 4 chars; implementation counts +1 per line as for a joining newline => 5 units/line.
+        # max_length 12 fits two lines per chunk; five lines => three chunks with ranges 1-2, 3-4, 5-5.
+        lines = ["AAAA", "BBBB", "CCCC", "DDDD", "EEEE"]
+        text = "\n".join(lines)
+        spans = chunk_content_with_spans(text, 12)
+        self.assertEqual(len(spans), 3)
+        self.assertEqual(spans[0][1:], (1, 2))
+        self.assertEqual(spans[1][1:], (3, 4))
+        self.assertEqual(spans[2][1:], (5, 5))
+
+    def test_oversized_single_line_is_split_by_max_length(self):
+        long_line = "x" * 50
+        spans = chunk_content_with_spans(long_line, 10)
+        self.assertEqual(len(spans), 5)
+        self.assertEqual("".join(t[0] for t in spans), long_line)
+        for text, start, end in spans:
+            self.assertEqual((start, end), (1, 1))
+            self.assertLessEqual(len(text), 10)
+
+
+class TestChunkDeepLineEnrichment(unittest.TestCase):
+    def test_model_copy_overwrites_line_fields(self):
+        from oasis.schemas.analysis import ChunkDeepAnalysis, VulnerabilityFinding
+
+        base = ChunkDeepAnalysis(
+            findings=[
+                VulnerabilityFinding(
+                    title="t",
+                    vulnerable_code="c",
+                    explanation="e",
+                    severity="Low",
+                )
+            ],
+            start_line=99,
+            end_line=100,
+        )
+        merged = base.model_copy(update={"start_line": 10, "end_line": 20})
+        self.assertEqual(merged.start_line, 10)
+        self.assertEqual(merged.end_line, 20)
+        self.assertEqual(len(merged.findings), 1)

--- a/tests/test_config_report.py
+++ b/tests/test_config_report.py
@@ -1,0 +1,35 @@
+"""Tests for REPORT-related configuration validation."""
+
+import unittest
+
+from oasis.config import validate_report_dashboard_formats
+
+
+class TestValidateReportDashboardFormats(unittest.TestCase):
+    def test_detects_unknown_dashboard_order_entry(self):
+        with self.assertLogs("oasis.config", level="WARNING"):
+            bad = validate_report_dashboard_formats(
+                {
+                    "OUTPUT_FORMATS": ["json", "md"],
+                    "DASHBOARD_FORMAT_DISPLAY_ORDER": ["html", "json"],
+                }
+            )
+        self.assertEqual(bad, ["html"])
+
+    def test_empty_when_consistent(self):
+        bad = validate_report_dashboard_formats(
+            {
+                "OUTPUT_FORMATS": ["json", "md"],
+                "DASHBOARD_FORMAT_DISPLAY_ORDER": ["md", "json"],
+            }
+        )
+        self.assertEqual(bad, [])
+
+    def test_case_insensitive_match(self):
+        bad = validate_report_dashboard_formats(
+            {
+                "OUTPUT_FORMATS": ["json", "SARIF"],
+                "DASHBOARD_FORMAT_DISPLAY_ORDER": ["sarif", "json"],
+            }
+        )
+        self.assertEqual(bad, [])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -76,3 +76,72 @@ class TestSarifExport(unittest.TestCase):
         locs = results[0].get("locations") or []
         self.assertTrue(locs)
         self.assertEqual(locs[0]["physicalLocation"]["artifactLocation"]["uri"], "app/routes.py")
+
+    def test_sarif_region_includes_chunk_line_span(self):
+        doc = VulnerabilityReportDocument(
+            title="Test",
+            generated_at="2026-01-01T00:00:00",
+            model_name="m",
+            vulnerability_name="XSS",
+            vulnerability={"name": "XSS", "description": "d"},
+            files=[
+                FileReportEntry(
+                    file_path="src/x.js",
+                    similarity_score=1.0,
+                    chunk_analyses=[
+                        ChunkDeepAnalysis(
+                            findings=[
+                                VulnerabilityFinding(
+                                    title="Reflected",
+                                    vulnerable_code="innerHTML = x",
+                                    explanation="DOM XSS.",
+                                    severity="High",
+                                )
+                            ],
+                            start_line=40,
+                            end_line=55,
+                        )
+                    ],
+                )
+            ],
+        )
+        payload = vulnerability_document_to_sarif(doc, tool_version="0.5.0-test")
+        region = payload["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+        self.assertEqual(region.get("startLine"), 40)
+        self.assertEqual(region.get("endLine"), 55)
+        self.assertIn("snippet", region)
+
+    def test_sarif_region_prefers_finding_snippet_span(self):
+        doc = VulnerabilityReportDocument(
+            title="Test",
+            generated_at="2026-01-01T00:00:00",
+            model_name="m",
+            vulnerability_name="SQL Injection",
+            vulnerability={"name": "SQL Injection"},
+            files=[
+                FileReportEntry(
+                    file_path="app.php",
+                    similarity_score=1.0,
+                    chunk_analyses=[
+                        ChunkDeepAnalysis(
+                            findings=[
+                                VulnerabilityFinding(
+                                    title="Unsafe",
+                                    vulnerable_code="cursor.execute(q)",
+                                    explanation="SQLi",
+                                    severity="High",
+                                    snippet_start_line=12,
+                                    snippet_end_line=14,
+                                )
+                            ],
+                            start_line=50,
+                            end_line=300,
+                        )
+                    ],
+                )
+            ],
+        )
+        payload = vulnerability_document_to_sarif(doc, tool_version="0.5.0-test")
+        region = payload["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+        self.assertEqual(region.get("startLine"), 12)
+        self.assertEqual(region.get("endLine"), 14)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,78 @@
+"""Tests for export helpers and SARIF generation."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.export.filenames import artifact_filename, report_dir_glob_for_format
+from oasis.export.sarif import vulnerability_document_to_sarif
+from oasis.schemas.analysis import (
+    ChunkDeepAnalysis,
+    FileReportEntry,
+    VulnerabilityFinding,
+    VulnerabilityReportDocument,
+)
+
+
+class TestArtifactFilename(unittest.TestCase):
+    def test_json_suffix(self):
+        self.assertEqual(artifact_filename("sql_injection", "json"), "sql_injection.json")
+
+    def test_sarif_suffix(self):
+        self.assertEqual(artifact_filename("sql_injection", "sarif"), "sql_injection.sarif")
+
+
+class TestReportDirGlob(unittest.TestCase):
+    def test_globs_match_artifact_extensions(self):
+        self.assertEqual(report_dir_glob_for_format("json"), "*.json")
+        self.assertEqual(report_dir_glob_for_format("sarif"), "*.sarif")
+        self.assertEqual(report_dir_glob_for_format("md"), "*.md")
+        self.assertEqual(report_dir_glob_for_format("html"), "*.html")
+        self.assertEqual(report_dir_glob_for_format("pdf"), "*.pdf")
+
+    def test_glob_normalizes_mixed_case(self):
+        self.assertEqual(report_dir_glob_for_format("JSON"), "*.json")
+        self.assertEqual(report_dir_glob_for_format(" PDF "), "*.pdf")
+
+
+class TestSarifExport(unittest.TestCase):
+    def test_minimal_document_produces_run_and_result(self):
+        doc = VulnerabilityReportDocument(
+            title="SQL Injection Security Analysis",
+            generated_at="2026-01-01T00:00:00",
+            model_name="test-model",
+            vulnerability_name="SQL Injection",
+            vulnerability={"name": "SQL Injection", "description": "SQLi desc"},
+            files=[
+                FileReportEntry(
+                    file_path="app/routes.py",
+                    similarity_score=0.91,
+                    chunk_analyses=[
+                        ChunkDeepAnalysis(
+                            findings=[
+                                VulnerabilityFinding(
+                                    title="Unsafe query",
+                                    vulnerable_code="cursor.execute(q)",
+                                    explanation="User input reaches SQL.",
+                                    severity="High",
+                                )
+                            ]
+                        )
+                    ],
+                )
+            ],
+        )
+        payload = vulnerability_document_to_sarif(doc, tool_version="0.5.0-test")
+        self.assertEqual(payload.get("version"), "2.1.0")
+        runs = payload.get("runs") or []
+        self.assertEqual(len(runs), 1)
+        results = runs[0].get("results") or []
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].get("ruleId"), "sql-injection")
+        locs = results[0].get("locations") or []
+        self.assertTrue(locs)
+        self.assertEqual(locs[0]["physicalLocation"]["artifactLocation"]["uri"], "app/routes.py")

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -200,6 +200,22 @@ class TestReportSchema(unittest.TestCase):
         self.assertIn("**Example payloads**:", markdown)
         self.assertIn('<div class="page-break"></div>', markdown)
 
+    def test_chunk_analysis_to_markdown_includes_source_line_hint(self):
+        chunk = ChunkDeepAnalysis(
+            findings=[
+                VulnerabilityFinding(
+                    title="Issue",
+                    vulnerable_code="x",
+                    explanation="y",
+                    severity="Medium",
+                )
+            ],
+            start_line=2,
+            end_line=9,
+        )
+        markdown = chunk_analysis_to_markdown(chunk, 0)
+        self.assertIn("source lines 2-9", markdown)
+
     def test_chunk_analysis_to_markdown_no_findings_uses_notes(self):
         chunk = ChunkDeepAnalysis(
             findings=[],

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -1,0 +1,263 @@
+"""Tests for structured report schemas and stats aggregation."""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from oasis.schemas.analysis import (
+        ChunkDeepAnalysis,
+        DashboardStats,
+        FileReportEntry,
+        MediumRiskAnalysis,
+        ScanVerdict,
+        VulnerabilityFinding,
+        VulnerabilityReportDocument,
+        build_dashboard_stats,
+        chunk_analysis_to_markdown,
+    )
+except ModuleNotFoundError:
+    # Fallback for minimal test environments where package-level optional deps
+    # (imported by oasis.__init__) are not installed.
+    _spec = importlib.util.spec_from_file_location(
+        "oasis_schemas_analysis",
+        ROOT / "oasis" / "schemas" / "analysis.py",
+    )
+    _analysis = importlib.util.module_from_spec(_spec)
+    assert _spec and _spec.loader is not None
+    _spec.loader.exec_module(_analysis)
+    ChunkDeepAnalysis = _analysis.ChunkDeepAnalysis
+    DashboardStats = _analysis.DashboardStats
+    FileReportEntry = _analysis.FileReportEntry
+    MediumRiskAnalysis = _analysis.MediumRiskAnalysis
+    ScanVerdict = _analysis.ScanVerdict
+    VulnerabilityFinding = _analysis.VulnerabilityFinding
+    VulnerabilityReportDocument = _analysis.VulnerabilityReportDocument
+    build_dashboard_stats = _analysis.build_dashboard_stats
+    chunk_analysis_to_markdown = _analysis.chunk_analysis_to_markdown
+
+try:
+    from oasis.analyze import AdaptiveAnalysisPipeline, SecurityAnalyzer
+except ModuleNotFoundError:
+    AdaptiveAnalysisPipeline = None
+    SecurityAnalyzer = None
+
+
+class TestReportSchema(unittest.TestCase):
+    def test_build_dashboard_stats_counts_severities(self):
+        files = [
+            FileReportEntry(
+                file_path="a.py",
+                similarity_score=0.9,
+                chunk_analyses=[
+                    ChunkDeepAnalysis(
+                        findings=[
+                            VulnerabilityFinding(
+                                vulnerable_code="z",
+                                explanation="e0",
+                                severity="Critical",
+                            ),
+                            VulnerabilityFinding(
+                                vulnerable_code="x",
+                                explanation="e",
+                                severity="High",
+                            ),
+                            VulnerabilityFinding(
+                                vulnerable_code="y",
+                                explanation="e2",
+                                severity="Low",
+                            ),
+                        ]
+                    )
+                ],
+            )
+        ]
+        stats = build_dashboard_stats(files)
+        self.assertEqual(stats.total_findings, 3)
+        self.assertEqual(stats.critical_risk, 1)
+        self.assertEqual(stats.high_risk, 1)
+        self.assertEqual(stats.low_risk, 1)
+        self.assertEqual(stats.medium_risk, 0)
+        self.assertEqual(stats.files_analyzed, 1)
+
+    def test_build_dashboard_stats_excludes_errored_files_from_analyzed_count(self):
+        files = [
+            FileReportEntry(
+                file_path="ok.py",
+                similarity_score=0.9,
+                chunk_analyses=[ChunkDeepAnalysis(findings=[])],
+            ),
+            FileReportEntry(
+                file_path="failed.py",
+                similarity_score=0.1,
+                chunk_analyses=[],
+                error="analysis failed",
+            ),
+        ]
+        stats = build_dashboard_stats(files)
+        self.assertEqual(stats.files_analyzed, 1)
+
+    def test_vulnerability_report_document_roundtrip(self):
+        doc = VulnerabilityReportDocument(
+            title="SQL Injection Security Analysis",
+            generated_at="2026-01-01 12:00:00",
+            model_name="test-model",
+            vulnerability_name="SQL Injection",
+            vulnerability={"name": "SQL Injection"},
+            files=[
+                FileReportEntry(
+                    file_path="app.py",
+                    similarity_score=0.85,
+                    chunk_analyses=[ChunkDeepAnalysis(findings=[])],
+                )
+            ],
+            stats=DashboardStats(files_analyzed=1),
+        )
+        raw = doc.model_dump_json()
+        restored = VulnerabilityReportDocument.model_validate_json(raw)
+        self.assertEqual(restored.title, doc.title)
+        self.assertEqual(len(restored.files), 1)
+        self.assertEqual(restored.schema_version, doc.schema_version)
+        self.assertEqual(restored.stats.files_analyzed, doc.stats.files_analyzed)
+
+    def test_scan_verdict_accepts_error_value(self):
+        verdict = ScanVerdict.model_validate({"verdict": "ERROR"})
+        self.assertEqual(verdict.verdict, "ERROR")
+
+    def test_analysis_models_expose_validation_error_flag(self):
+        medium = MediumRiskAnalysis(risk_score=50, analysis="Invalid structured response", validation_error=True)
+        deep = ChunkDeepAnalysis(findings=[], notes="validation failure", validation_error=True)
+        self.assertTrue(medium.validation_error)
+        self.assertTrue(deep.validation_error)
+
+    def test_chunk_analysis_to_markdown_renders_multiple_findings(self):
+        chunk = ChunkDeepAnalysis(
+            findings=[
+                VulnerabilityFinding(
+                    title="User input flows to query",
+                    vulnerable_code="user_input = request.GET['q']",
+                    explanation="Unsanitized input reaches query builder.",
+                    severity="High",
+                    execution_path_diagram="handle -> do_query",
+                    http_methods=["GET"],
+                    manipulable_parameters=["q"],
+                    example_payloads=['{"q":"test"}'],
+                ),
+                VulnerabilityFinding(
+                    title="Eval usage",
+                    vulnerable_code="eval(user_input)",
+                    explanation="Dynamic execution of attacker-controlled input.",
+                    severity="Critical",
+                    execution_path_diagram="handler -> eval",
+                    http_methods=["POST"],
+                    manipulable_parameters=["user_input"],
+                    example_payloads=['{"user_input":"__import__(\\"os\\")"}'],
+                ),
+            ]
+        )
+
+        markdown = chunk_analysis_to_markdown(chunk, 0)
+        self.assertIn("#### Finding 1 (chunk 1): User input flows to query", markdown)
+        self.assertIn("#### Finding 2 (chunk 1): Eval usage", markdown)
+        self.assertIn("- **Severity**: High", markdown)
+        self.assertIn("- **Severity**: Critical", markdown)
+        self.assertIn("user_input = request.GET['q']", markdown)
+        self.assertIn("## Execution Path", markdown)
+        self.assertIn("**HTTP methods**: GET", markdown)
+        self.assertIn("**Parameters**: q", markdown)
+        self.assertIn("**Example payloads**:", markdown)
+        self.assertIn('<div class="page-break"></div>', markdown)
+
+    def test_chunk_analysis_to_markdown_no_findings_uses_notes(self):
+        chunk = ChunkDeepAnalysis(
+            findings=[],
+            notes="Static analysis only: no problematic patterns discovered.",
+        )
+        markdown = chunk_analysis_to_markdown(chunk, 2)
+        self.assertIn("No vulnerabilities identified in structured output.", markdown)
+        self.assertIn("**Notes**: Static analysis only: no problematic patterns discovered.", markdown)
+        self.assertNotIn("## Execution Path", markdown)
+
+    def test_chunk_analysis_to_markdown_inserts_page_breaks_between_findings(self):
+        chunk = ChunkDeepAnalysis(
+            findings=[
+                VulnerabilityFinding(
+                    title="First",
+                    vulnerable_code="a = 1",
+                    explanation="first",
+                    severity="Low",
+                ),
+                VulnerabilityFinding(
+                    title="Second",
+                    vulnerable_code="b = 2",
+                    explanation="second",
+                    severity="Medium",
+                ),
+            ]
+        )
+        markdown = chunk_analysis_to_markdown(chunk, 0)
+        self.assertGreaterEqual(markdown.count('<div class="page-break"></div>'), 2)
+
+    @unittest.skipIf(SecurityAnalyzer is None, "oasis.analyze dependencies are unavailable")
+    def test_structured_output_failure_flags_are_set_in_fallbacks(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.structured_output_failure_handler = None
+
+        medium_json = analyzer._resolve_structured_output_failure(
+            response_model=MediumRiskAnalysis,
+            raw='{"bad":"json"}',
+            error=ValueError("boom"),
+            model_display="test-model",
+        )
+        deep_json = analyzer._resolve_structured_output_failure(
+            response_model=ChunkDeepAnalysis,
+            raw='{"bad":"json"}',
+            error=ValueError("boom"),
+            model_display="test-model",
+        )
+
+        medium = MediumRiskAnalysis.model_validate_json(medium_json)
+        deep = ChunkDeepAnalysis.model_validate_json(deep_json)
+        self.assertTrue(medium.validation_error)
+        self.assertTrue(deep.validation_error)
+
+    @unittest.skipIf(AdaptiveAnalysisPipeline is None, "oasis.analyze dependencies are unavailable")
+    def test_identify_high_risk_chunks_skips_validation_errors(self):
+        pipeline = AdaptiveAnalysisPipeline.__new__(AdaptiveAnalysisPipeline)
+        suspicious_chunks = [(0, "chunk-a"), (1, "chunk-b"), (2, "chunk-c")]
+        medium_results = [
+            {"chunk_idx": 0, "risk_score": 90, "validation_error": False},
+            {"chunk_idx": 1, "risk_score": 99, "validation_error": True},
+            {"chunk_idx": 2, "risk_score": 40, "validation_error": False},
+        ]
+        selected = pipeline._identify_high_risk_chunks(
+            suspicious_chunks=suspicious_chunks,
+            medium_results=medium_results,
+            risk_threshold=70,
+        )
+        self.assertEqual(selected, [(0, "chunk-a")])
+
+    @unittest.skipIf(AdaptiveAnalysisPipeline is None, "oasis.analyze dependencies are unavailable")
+    def test_combine_adaptive_results_escapes_backticks_and_truncates_unparseable_notes(self):
+        pipeline = AdaptiveAnalysisPipeline.__new__(AdaptiveAnalysisPipeline)
+        raw = "```" + ("A" * 450)
+        combined = pipeline._combine_adaptive_results(
+            file_path="demo.py",
+            code_chunks=["chunk"],
+            suspicious_chunks=[],
+            medium_results=[],
+            deep_results=[{"chunk_idx": 0, "analysis": raw, "content": "x"}],
+        )
+        markdown = combined["markdown"]
+        self.assertIn("Unparseable deep analyses", markdown)
+        self.assertIn("``\\`", markdown)
+        self.assertIn("[truncated]", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -49,6 +50,32 @@ except ModuleNotFoundError:
 
 
 class TestReportSchema(unittest.TestCase):
+    @unittest.skipIf(SecurityAnalyzer is None, "oasis.analyze dependencies are unavailable")
+    def test_deep_analysis_updates_main_progress_by_one_per_vulnerability(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.llm_model = "test-model"
+        analyzer.ollama_manager = SimpleNamespace(get_model_display_name=lambda _model: "test-model")
+        vulnerabilities = [{"name": "SQL Injection"}, {"name": "XSS"}]
+        suspicious_files_by_vuln = {
+            "sql": {"vuln_data": vulnerabilities[0], "files": [("app.py", 0.9)]},
+            "xss": {"vuln_data": vulnerabilities[1], "files": [("app.py", 0.8)]},
+        }
+        suspicious_data = {"suspicious_data": {}, "files_by_vuln": suspicious_files_by_vuln}
+
+        analyzer._analyze_vulnerability_deep = lambda *args, **kwargs: []
+
+        updates = []
+        main_pbar = SimpleNamespace(
+            set_postfix_str=lambda _text: None,
+            update=lambda value: updates.append(value),
+        )
+        report = SimpleNamespace(generate_vulnerability_report=lambda **kwargs: None)
+        args = SimpleNamespace(silent=True)
+
+        analyzer._perform_deep_analysis(suspicious_data, args, report, main_pbar)
+
+        self.assertEqual(updates, [1, 1])
+
     def test_build_dashboard_stats_counts_severities(self):
         files = [
             FileReportEntry(
@@ -245,6 +272,11 @@ class TestReportSchema(unittest.TestCase):
     @unittest.skipIf(AdaptiveAnalysisPipeline is None, "oasis.analyze dependencies are unavailable")
     def test_combine_adaptive_results_escapes_backticks_and_truncates_unparseable_notes(self):
         pipeline = AdaptiveAnalysisPipeline.__new__(AdaptiveAnalysisPipeline)
+        pipeline.analyzer = SimpleNamespace(
+            _log_structured_output_error=lambda **kwargs: None,
+            ollama_manager=SimpleNamespace(get_model_display_name=lambda _model: "test-model"),
+            llm_model="test-model",
+        )
         raw = "```" + ("A" * 450)
         combined = pipeline._combine_adaptive_results(
             file_path="demo.py",

--- a/tests/test_snippet_lines.py
+++ b/tests/test_snippet_lines.py
@@ -1,0 +1,38 @@
+"""Tests for snippet-to-line resolution (no heavy oasis.tools dependency)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.snippet_lines import absolute_snippet_lines_in_file, substring_line_span_1based
+
+
+class TestSubstringLineSpan(unittest.TestCase):
+    def test_single_line_snippet(self):
+        haystack = "a\nb\nc\nd"
+        self.assertEqual(substring_line_span_1based(haystack, "c"), (3, 3))
+
+    def test_multiline_snippet(self):
+        haystack = "L1\nL2\nL3\nL4"
+        self.assertEqual(substring_line_span_1based(haystack, "L2\nL3"), (2, 3))
+
+    def test_php_chunk_sql_injection_lines(self):
+        php = Path(ROOT / "test_files" / "vulnerable.php").read_text(encoding="utf-8")
+        needle = (
+            '$query = "SELECT * FROM users WHERE username = \'$username\'";\n'
+            "    return $conn->query($query);"
+        )
+        rel = substring_line_span_1based(php, needle)
+        self.assertIsNotNone(rel)
+        assert rel is not None
+        self.assertEqual(rel, (6, 7))
+
+    def test_absolute_lines_single_chunk_file(self):
+        php = Path(ROOT / "test_files" / "vulnerable.php").read_text(encoding="utf-8")
+        needle = '$query = "SELECT * FROM users WHERE username = \'$username\'";'
+        abs_lines = absolute_snippet_lines_in_file(php, 1, needle)
+        self.assertEqual(abs_lines, (6, 6))

--- a/tests/test_structured_output_parsing.py
+++ b/tests/test_structured_output_parsing.py
@@ -1,0 +1,424 @@
+"""Tests for structured output normalization and retry behavior."""
+
+import importlib.util
+import json
+import random
+import sys
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from oasis.schemas.analysis import ChunkDeepAnalysis
+except ModuleNotFoundError:
+    _spec = importlib.util.spec_from_file_location(
+        "oasis_schemas_analysis",
+        ROOT / "oasis" / "schemas" / "analysis.py",
+    )
+    _analysis = importlib.util.module_from_spec(_spec)
+    assert _spec and _spec.loader is not None
+    _spec.loader.exec_module(_analysis)
+    ChunkDeepAnalysis = _analysis.ChunkDeepAnalysis
+
+try:
+    from oasis.structured_output.deep import (
+        apply_normalizer_by_path,
+        chunk_deep_normalization_change_samples,
+    )
+except ImportError:
+    apply_normalizer_by_path = None
+    chunk_deep_normalization_change_samples = None
+
+try:
+    from oasis.structured_output.json_repair import (
+        fix_invalid_json_string_escapes,
+        scan_open_delimiter_stack_outside_strings,
+        strip_code_fences,
+    )
+except ImportError:
+    fix_invalid_json_string_escapes = None
+    scan_open_delimiter_stack_outside_strings = None
+    strip_code_fences = None
+
+try:
+    from oasis.analyze import SecurityAnalyzer, _get_structured_deep_instructions
+except ImportError:
+    SecurityAnalyzer = None
+    _get_structured_deep_instructions = None
+
+
+@unittest.skipIf(
+    strip_code_fences is None,
+    "oasis.structured_output.json_repair is unavailable",
+)
+class TestStripCodeFences(unittest.TestCase):
+    def test_strips_outer_fences_only(self):
+        raw = '```json\n{"a": 1}\n```\n'
+        self.assertEqual(strip_code_fences(raw).strip(), '{"a": 1}')
+
+    def test_preserves_fence_line_inside_json_string_at_line_start(self):
+        # Inner `` ``` `` at column 0 after a newline must not be treated as closing fence.
+        inner = '{"notes": "line1\n```\nline2"}'
+        wrapped = "```json\n" + inner + "\n```"
+        out = strip_code_fences(wrapped)
+        self.assertIn("```", out)
+        self.assertIn("line1", out)
+        self.assertIn("line2", out)
+
+
+@unittest.skipIf(
+    scan_open_delimiter_stack_outside_strings is None,
+    "oasis.structured_output.json_repair is unavailable",
+)
+class TestScanOpenDelimiterStack(unittest.TestCase):
+    def test_truncated_object_returns_open_brace(self):
+        self.assertEqual(scan_open_delimiter_stack_outside_strings('{"a":1'), ["{"])
+
+    def test_balanced_returns_empty_stack(self):
+        self.assertEqual(scan_open_delimiter_stack_outside_strings('{"a":1}'), [])
+
+    def test_mismatch_returns_none(self):
+        self.assertIsNone(scan_open_delimiter_stack_outside_strings("{]"))
+
+    def test_truncated_inside_string_returns_none(self):
+        self.assertIsNone(scan_open_delimiter_stack_outside_strings('{"x":"'))
+
+    def test_nested_brackets_with_closers_inside_string_literals(self):
+        # ``]`` and ``}`` inside the string value must not pop the stack; outer object is truncated.
+        s = '{"a":[{"b":"x]y"}]'
+        self.assertEqual(scan_open_delimiter_stack_outside_strings(s), ["{"])
+
+
+@unittest.skipIf(
+    fix_invalid_json_string_escapes is None,
+    "oasis.structured_output.json_repair is unavailable",
+)
+class TestFixInvalidJsonStringEscapes(unittest.TestCase):
+    def test_invalid_escape_doubles_backslash(self):
+        raw = r'{"k":"\x"}'
+        fixed = fix_invalid_json_string_escapes(raw)
+        self.assertEqual(json.loads(fixed)["k"], r"\x")
+
+    def test_valid_unicode_escape_unchanged(self):
+        raw = r'{"k":"\u0041"}'
+        fixed = fix_invalid_json_string_escapes(raw)
+        self.assertEqual(json.loads(fixed)["k"], "A")
+
+    def test_already_escaped_backslash_not_modified(self):
+        raw = r'{"k":"\\x"}'
+        fixed = fix_invalid_json_string_escapes(raw)
+        self.assertEqual(json.loads(fixed)["k"], r"\x")
+
+    def test_invalid_partial_unicode_escape_is_repairable(self):
+        raw = r'{"k":"\u12"}'
+        fixed = fix_invalid_json_string_escapes(raw)
+        parsed = json.loads(fixed)
+        self.assertIn("k", parsed)
+        self.assertIsInstance(parsed["k"], str)
+
+
+@unittest.skipIf(
+    apply_normalizer_by_path is None,
+    "oasis.structured_output.deep is unavailable",
+)
+class TestWildcardNormalizerPath(unittest.TestCase):
+    def test_star_skips_non_dict_list_elements(self):
+        payload = {
+            "findings": [
+                {"tags": ["a", "b"]},
+                "not-a-dict",
+                {"tags": ["c"]},
+            ]
+        }
+
+        def _norm(v: list) -> list:
+            return v + ["seen"]
+
+        changed = apply_normalizer_by_path(
+            payload,
+            ("findings", "*", "tags"),
+            _norm,
+        )
+        self.assertTrue(changed)
+        self.assertEqual(payload["findings"][0]["tags"], ["a", "b", "seen"])
+        self.assertEqual(payload["findings"][1], "not-a-dict")
+        self.assertEqual(payload["findings"][2]["tags"], ["c", "seen"])
+
+    def test_star_on_non_list_container_is_no_op(self):
+        payload = {"findings": {"0": {"tags": []}}}
+        changed = apply_normalizer_by_path(
+            payload,
+            ("findings", "*", "tags"),
+            lambda v: v,
+        )
+        self.assertFalse(changed)
+
+
+@unittest.skipIf(
+    chunk_deep_normalization_change_samples is None,
+    "oasis.structured_output.deep is unavailable",
+)
+class TestNormalizationChangeSamples(unittest.TestCase):
+    def test_reports_before_after_for_changed_finding_field(self):
+        before = {
+            "findings": [
+                {"exploitation_conditions": ["a", "b"], "severity": "Low"},
+            ]
+        }
+        after = {
+            "findings": [
+                {"exploitation_conditions": "a; b", "severity": "Low"},
+            ]
+        }
+        samples = chunk_deep_normalization_change_samples(before, after, max_items=5)
+        cond = next(
+            s for s in samples if s["path"] == "findings[0].exploitation_conditions"
+        )
+        self.assertEqual(cond["before"], ["a", "b"])
+        self.assertEqual(cond["after"], "a; b")
+
+    def test_multiple_findings_only_changed_fields_included(self):
+        before = {
+            "findings": [
+                {
+                    "exploitation_conditions": ["a", "b"],
+                    "severity": "Low",
+                    "title": "Finding 1",
+                },
+                {
+                    "exploitation_conditions": ["x"],
+                    "severity": "High",
+                    "title": "Finding 2",
+                },
+            ]
+        }
+        after = {
+            "findings": [
+                {
+                    "exploitation_conditions": "a; b",
+                    "severity": "Low",
+                    "title": "Finding 1",
+                },
+                {
+                    "exploitation_conditions": ["x"],
+                    "severity": "Critical",
+                    "title": "Finding 2",
+                },
+            ]
+        }
+
+        samples = chunk_deep_normalization_change_samples(before, after, max_items=10)
+        paths = {s["path"] for s in samples}
+        expected_changed_paths = {
+            "findings[0].exploitation_conditions",
+            "findings[1].severity",
+        }
+        self.assertEqual(paths, expected_changed_paths)
+
+        cond_0 = next(
+            s for s in samples if s["path"] == "findings[0].exploitation_conditions"
+        )
+        self.assertEqual(cond_0["before"], ["a", "b"])
+        self.assertEqual(cond_0["after"], "a; b")
+
+        sev_1 = next(s for s in samples if s["path"] == "findings[1].severity")
+        self.assertEqual(sev_1["before"], "High")
+        self.assertEqual(sev_1["after"], "Critical")
+
+
+@unittest.skipIf(SecurityAnalyzer is None, "oasis.analyze dependencies are unavailable")
+class TestStructuredOutputParsing(unittest.TestCase):
+    def test_parse_normalizes_exploitation_conditions_list(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        raw = json.dumps(
+            {
+                "findings": [
+                    {
+                        "title": "SQL interpolation",
+                        "vulnerable_code": "query = f\"SELECT * FROM users WHERE id={user_id}\"",
+                        "explanation": "Input reaches SQL query without parameterization.",
+                        "severity": "High",
+                        "impact": "Data leakage",
+                        "entry_point": "GET /users",
+                        "exploitation_conditions": [
+                            "Attacker can reach endpoint",
+                            "Input is unsanitized",
+                        ],
+                    }
+                ]
+            }
+        )
+
+        normalized = analyzer._parse_structured_output_response(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = json.loads(normalized)
+        self.assertEqual(
+            parsed["findings"][0]["exploitation_conditions"],
+            "Attacker can reach endpoint; Input is unsanitized",
+        )
+
+    def test_retryable_error_detects_known_string_type_mismatch(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        with self.assertRaises(ValidationError) as ctx:
+            ChunkDeepAnalysis.model_validate(
+                {
+                    "findings": [
+                        {
+                            "vulnerable_code": "a",
+                            "explanation": "b",
+                            "severity": "Low",
+                            "exploitation_conditions": ["bad"],
+                        }
+                    ]
+                }
+            )
+        self.assertTrue(analyzer._is_retryable_structured_error(ChunkDeepAnalysis, ctx.exception))
+
+    def test_retryable_error_ignores_non_exploitation_conditions_errors(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        with self.assertRaises(ValidationError) as ctx:
+            ChunkDeepAnalysis.model_validate(
+                {
+                    "findings": [
+                        {
+                            "vulnerable_code": "a",
+                            "explanation": "b",
+                            "severity": "NotAValidSeverity",
+                            "exploitation_conditions": (
+                                "Attacker can reach endpoint; Input is unsanitized"
+                            ),
+                        }
+                    ]
+                }
+            )
+        self.assertFalse(
+            analyzer._is_retryable_structured_error(ChunkDeepAnalysis, ctx.exception)
+        )
+
+    def test_deep_prompt_contains_type_guardrails_for_conditions(self):
+        prompt = _get_structured_deep_instructions("SQL Injection")
+        self.assertIn("exploitation_conditions MUST be a single string sentence (not list).", prompt)
+        self.assertIn("Valid vs invalid typing examples:", prompt)
+        self.assertIn("Escape any `\\\"` characters inside string values", prompt)
+        self.assertIn(
+            'return a minimal object like {"findings": [], "notes": "Unable to produce confident structured output"',
+            prompt,
+        )
+        self.assertIn(
+            "Do NOT include markdown code fences (``` or similar) anywhere inside field values.",
+            prompt,
+        )
+
+    def test_repair_structured_json_raw_closes_unbalanced_payload(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        raw = (
+            '{"findings":[{"title":"X","vulnerable_code":"a","explanation":"b","severity":"Low",'
+            '"exploitation_conditions":"c"}'
+        )
+        repaired = analyzer._repair_structured_json_raw(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+        self.assertEqual(len(parsed.findings), 1)
+
+    def test_repair_structured_json_raw_removes_control_chars(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        raw = '{"findings":[],"notes":"hello\x01world"}'
+        repaired = analyzer._repair_structured_json_raw(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+        self.assertIn("helloworld", parsed.notes or "")
+
+    def test_repair_structured_json_raw_uses_minimal_fallback_on_unrecoverable_payload(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        raw = 'garbage-prefix {"findings": [INVALID JSON!!!] missing-quotes-and-braces'
+        repaired = analyzer._repair_structured_json_raw(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+        self.assertIsInstance(parsed, ChunkDeepAnalysis)
+        self.assertEqual(parsed.findings, [])
+        self.assertTrue(parsed.validation_error)
+        self.assertTrue(parsed.potential_vulnerabilities)
+
+    def test_repair_structured_json_raw_preserves_valid_json_with_escaped_content(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        raw_payload = {
+            "findings": [],
+            "notes": 'Contains braces { } and brackets [ ] and comma , and escaped quote \\" and backslash \\\\',
+        }
+        raw = json.dumps(raw_payload)
+        repaired = analyzer._repair_structured_json_raw(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+        self.assertEqual(parsed.notes, raw_payload["notes"])
+
+    def test_repair_structured_json_raw_randomized_notes_are_stable(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        charset = list('abc{}[],: "\\\\\n\t')
+        for _ in range(20):
+            note = "".join(random.choice(charset) for _ in range(40))
+            raw = json.dumps({"findings": [], "notes": note})
+            repaired = analyzer._repair_structured_json_raw(
+                raw=raw,
+                response_model=ChunkDeepAnalysis,
+                model_display="test-model",
+            )
+            parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+            self.assertEqual(parsed.notes, note)
+
+    def test_build_safe_minimal_chunk_json_returns_valid_payload(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        broken = '{"findings": [], "notes": "incomplete'
+        safe = analyzer._build_safe_minimal_chunk_json(broken)
+        self.assertIsNotNone(safe)
+        parsed = ChunkDeepAnalysis.model_validate_json(safe)
+        self.assertTrue(parsed.validation_error)
+        self.assertTrue(parsed.potential_vulnerabilities)
+
+    def test_repair_structured_json_raw_strips_trailing_garbage_after_object(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        core = {"findings": [], "notes": "ok", "validation_error": False}
+        raw = json.dumps(core) + "\n\nExtra prose after JSON that breaks json.loads."
+        repaired = analyzer._repair_structured_json_raw(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+        self.assertEqual(parsed.notes, "ok")
+        self.assertEqual(parsed.findings, [])
+
+    def test_repair_structured_json_raw_fixes_invalid_escapes_in_strings(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        # \\x is not a valid JSON escape; model often emits shell/Python-like snippets.
+        raw = r'{"findings":[],"notes":"bad \x escape"}'
+        repaired = analyzer._repair_structured_json_raw(
+            raw=raw,
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = ChunkDeepAnalysis.model_validate_json(repaired)
+        self.assertEqual(parsed.notes, r"bad \x escape")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix #24 #32 

- Introduces Pydantic-based structured models for scan, medium, and deep analysis, including per-chunk and per-finding metadata (line spans, severity, exploitation details).

- Adds robust Ollama structured-output handling with normalization, JSON repair, retries, and error logging, and enriches findings with source line information.

- Switches reporting to a JSON-first pipeline that aggregates structured findings into canonical vulnerability documents, from which HTML, PDF, markdown, and SARIF artifacts are derived.

- Updates the web dashboard and APIs to consume JSON reports for statistics, previews, and downloads, with safer path handling, format-aware UI, and improved error messaging.
  <img width="346" height="428" alt="image" src="https://github.com/user-attachments/assets/632eb5e7-6af9-4218-8165-a9c0ea692e6a" />

- Extends function extraction to use structured JSON responses with a regex-based fallback, and enhances chunking utilities to track line spans.

- Revises CLI and configuration to support multiple output formats (including JSON and SARIF) with validated format ordering, and introduces per-run logging tied to report directories.

## SARIF file in VSCode with SARIF Viewer
<img width="1822" height="652" alt="sarif-vscode" src="https://github.com/user-attachments/assets/9e090bdf-0ee8-46f2-8756-12d283cd834d" />

