### PR TITLE
feat: add optional development dependencies and enhance test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ dependencies = [
     "flask-socketio>=5.3.6",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "coverage>=7.0.0",
+]
+
 [project.scripts]
 oasis = "oasis:main"
 

--- a/tests/test_analyze_orchestration.py
+++ b/tests/test_analyze_orchestration.py
@@ -1,0 +1,151 @@
+"""Unit tests for SecurityAnalyzer orchestration (standard vs adaptive, phase ordering)."""
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from oasis.analyze import SecurityAnalyzer
+except ModuleNotFoundError:
+    SecurityAnalyzer = None
+
+
+@unittest.skipIf(SecurityAnalyzer is None, "oasis.analyze dependencies are unavailable")
+class TestAnalyzeOrchestration(unittest.TestCase):
+    def test_perform_standard_analysis_runs_initial_scan_then_deep(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        order = []
+
+        def stub_initial(vulnerabilities, args, main_pbar, report, *, n_vuln_types):
+            order.append("initial")
+            self.assertEqual(n_vuln_types, 1)
+            return {"stub": "suspicious_payload"}
+
+        def stub_deep(suspicious_data, args, report, main_pbar=None, *, n_vuln_types):
+            order.append("deep")
+            self.assertEqual(suspicious_data["stub"], "suspicious_payload")
+            self.assertEqual(n_vuln_types, 1)
+            return {"_inj": [{"chunk": 1}]}
+
+        analyzer._perform_initial_scanning = stub_initial
+        analyzer._perform_deep_analysis = stub_deep
+
+        vulns = [{"name": "SQL Injection"}]
+        args = SimpleNamespace(silent=True)
+        report = SimpleNamespace()
+
+        out = analyzer._perform_standard_analysis(vulns, args, report)
+
+        self.assertEqual(order, ["initial", "deep"])
+        self.assertEqual(out, {"_inj": [{"chunk": 1}]})
+
+    @patch("oasis.analyze.publish_incremental_summary")
+    @patch("oasis.analyze.safe_code_base_file_count", return_value=7)
+    def test_process_analysis_with_model_standard_final_uses_standard_progress_extras(
+        self, _mock_count, mock_publish
+    ):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.llm_model = "main-model"
+        analyzer.analysis_pipeline = SimpleNamespace()
+
+        captured = {}
+
+        def fake_standard(vulnerabilities, args, report):
+            captured["called"] = True
+            self.assertEqual(len(vulnerabilities), 1)
+            return {"inj": []}
+
+        analyzer._perform_standard_analysis = fake_standard
+
+        vulns = [{"name": "XSS"}]
+        args = SimpleNamespace(silent=True, adaptive=False)
+        report = SimpleNamespace(generate_executive_summary=lambda *a, **k: None)
+
+        analyzer.process_analysis_with_model(vulns, args, report)
+
+        self.assertTrue(captured.get("called"))
+        mock_publish.assert_called()
+        final_kw = mock_publish.call_args.kwargs
+        self.assertEqual(final_kw.get("completed_vulnerabilities"), 1)
+        self.assertEqual(final_kw.get("total_vulnerabilities"), 1)
+        self.assertEqual(final_kw.get("vulnerability_types_total"), 1)
+        self.assertIn("phases", final_kw)
+
+    @patch("oasis.analyze.publish_incremental_summary")
+    @patch("oasis.analyze.safe_code_base_file_count", return_value=3)
+    def test_process_analysis_with_model_adaptive_final_uses_adaptive_progress_extras(
+        self, _mock_count, mock_publish
+    ):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.llm_model = "main-model"
+        pipeline = SimpleNamespace()
+
+        def fake_adaptive(vulnerabilities, args, report):
+            return {"a": [], "b": []}
+
+        pipeline.perform_adaptive_analysis = fake_adaptive
+        analyzer.analysis_pipeline = pipeline
+
+        vulns = [{"name": "A"}, {"name": "B"}]
+        args = SimpleNamespace(silent=True, adaptive=True)
+        report = SimpleNamespace(generate_executive_summary=lambda *a, **k: None)
+
+        out = analyzer.process_analysis_with_model(vulns, args, report)
+
+        self.assertEqual(out, {"a": [], "b": []})
+        mock_publish.assert_called()
+        final_kw = mock_publish.call_args.kwargs
+        self.assertEqual(final_kw.get("completed_vulnerabilities"), 2)
+        self.assertEqual(final_kw.get("total_vulnerabilities"), 2)
+        self.assertIn("adaptive_subphases", final_kw)
+
+    @patch("oasis.analyze.publish_incremental_summary")
+    @patch("oasis.analyze.safe_code_base_file_count", return_value=1)
+    def test_process_analysis_with_model_returns_pipeline_results(self, _mock_count, _mock_pub):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.llm_model = "m"
+        analyzer.analysis_pipeline = SimpleNamespace(
+            perform_adaptive_analysis=lambda v, a, r: {"k": "v"}
+        )
+
+        args = SimpleNamespace(silent=True, adaptive=True)
+        report = SimpleNamespace(generate_executive_summary=lambda *a, **k: None)
+
+        self.assertEqual(
+            analyzer.process_analysis_with_model([], args, report),
+            {"k": "v"},
+        )
+
+    def test_get_vulnerabilities_to_check_all_returns_full_mapping(self):
+        args = SimpleNamespace(vulns="all")
+        mapping = {"sql": {"name": "SQL"}, "xss": {"name": "XSS"}}
+        vulns, invalid = SecurityAnalyzer.get_vulnerabilities_to_check(args, mapping)
+        self.assertIsNone(invalid)
+        self.assertEqual({v["name"] for v in vulns}, {"SQL", "XSS"})
+
+    def test_get_vulnerabilities_to_check_invalid_tag_returns_error(self):
+        args = SimpleNamespace(vulns="sql,not_a_tag")
+        mapping = {"sql": {"name": "SQL"}}
+        vulns, invalid = SecurityAnalyzer.get_vulnerabilities_to_check(args, mapping)
+        self.assertIsNone(vulns)
+        self.assertEqual(invalid, ["not_a_tag"])
+
+    def test_get_vulnerabilities_to_check_respects_tag_order(self):
+        args = SimpleNamespace(vulns="sql, xss")
+        mapping = {
+            "sql": {"name": "SQL"},
+            "xss": {"name": "XSS"},
+        }
+        vulns, invalid = SecurityAnalyzer.get_vulnerabilities_to_check(args, mapping)
+        self.assertIsNone(invalid)
+        self.assertEqual([v["name"] for v in vulns], ["SQL", "XSS"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analyze_scoring.py
+++ b/tests/test_analyze_scoring.py
@@ -1,0 +1,61 @@
+"""Unit tests for SecurityAnalyzer embedding similarity paths (no LLM)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from oasis.analyze import SecurityAnalyzer
+except ImportError:
+    SecurityAnalyzer = None
+
+
+@unittest.skipIf(SecurityAnalyzer is None, "oasis.analyze dependencies are unavailable")
+class TestSecurityAnalyzerScoring(unittest.TestCase):
+    def test_process_functions_appends_when_similarity_meets_threshold(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        results = []
+        data = {
+            "functions": {
+                "fn_a": {"embedding": [1.0, 0.0, 0.0]},
+                "fn_b": {"embedding": [0.0, 1.0, 0.0]},
+            }
+        }
+        analyzer._process_functions("f.py", data, [1.0, 0.0, 0.0], 0.9, results)
+        self.assertEqual(results, [("fn_a", 1.0)])
+
+    def test_process_functions_skips_missing_embeddings(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        results = []
+        data = {"functions": {"fn_a": {}}}
+        analyzer._process_functions("f.py", data, [1.0, 0.0], 0.5, results)
+        self.assertEqual(results, [])
+
+    def test_process_file_single_vector_branch(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        results = []
+        data = {"embedding": [1.0, 0.0]}
+        analyzer._process_file("app.py", data, [1.0, 0.0], 0.99, results)
+        self.assertEqual(results, [("app.py", 1.0)])
+
+    def test_process_file_chunked_vectors_branch(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        results = []
+        data = {"embedding": [[1.0, 0.0], [0.0, 1.0]]}
+        analyzer._process_file("chunked.py", data, [1.0, 0.0], 0.99, results)
+        self.assertEqual(results, [("chunked.py", 1.0)])
+
+    def test_process_file_below_threshold_no_append(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        results = []
+        data = {"embedding": [1.0, 0.0]}
+        analyzer._process_file("low.py", data, [0.0, 1.0], 0.99, results)
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,67 @@
+"""Tests for CacheManager paths, keys, and scan cache clearing."""
+
+import pickle
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.cache import CacheManager
+from oasis.enums import AnalysisMode, AnalysisType
+from oasis.schemas.analysis import ANALYSIS_SCHEMA_VERSION
+
+
+class TestCacheManager(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        self.base = Path(self._td)
+        self.proj = self.base / "demo_proj"
+        self.proj.mkdir()
+        self.target_file = self.proj / "main.py"
+        self.target_file.write_text("print('hi')\n", encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def test_get_cache_path_standard_scan(self):
+        cm = CacheManager(self.target_file, "MainModel", "ScanModel", cache_days=365)
+        p = cm.get_cache_path("nest/main.py", AnalysisMode.SCAN, AnalysisType.STANDARD)
+        self.assertEqual(p.parent, cm.standard_cache_dir[AnalysisMode.SCAN])
+        self.assertTrue(str(p.name).endswith(".cache"))
+
+    def test_generate_cache_key_includes_schema_version_and_hashes(self):
+        cm = CacheManager(self.target_file, "m1", "m2", cache_days=365)
+        key = cm.generate_cache_key('print("x")', "prompt text", "SQL Injection")
+        self.assertTrue(key.startswith(f"v{ANALYSIS_SCHEMA_VERSION}_"))
+
+    def test_clear_scan_cache_removes_cache_files(self):
+        cm = CacheManager(self.target_file, "m1", "m2", cache_days=365)
+        scan_dir = cm.standard_cache_dir[AnalysisMode.SCAN]
+        dummy = scan_dir / "dummy.cache"
+        dummy.write_bytes(pickle.dumps({"payload": True}))
+
+        cm.clear_scan_cache(AnalysisType.STANDARD)
+
+        self.assertFalse(dummy.exists())
+
+    def test_process_cache_save_then_load_roundtrip(self):
+        cm = CacheManager(self.target_file, "m1", "m2", cache_days=365)
+        fp = "src/module.py"
+        payload = {"chunk_key": {"result": "cached"}}
+        cm.chunk_cache[AnalysisType.STANDARD][fp] = payload
+
+        cm.process_cache("save", fp, AnalysisMode.DEEP, AnalysisType.STANDARD)
+
+        cm.chunk_cache[AnalysisType.STANDARD] = {}
+        loaded = cm.process_cache("load", fp, AnalysisMode.DEEP, AnalysisType.STANDARD)
+
+        self.assertEqual(loaded, payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_embedding_pure.py
+++ b/tests/test_embedding_pure.py
@@ -1,0 +1,88 @@
+"""Pure-function tests for embedding helpers (no Ollama / network)."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.config import EMBEDDING_THRESHOLDS
+from oasis.embedding import build_vulnerability_embedding_prompt, generate_content_embedding
+
+try:
+    from oasis.analyze import EmbeddingAnalyzer
+except ImportError:
+    EmbeddingAnalyzer = None
+
+
+class TestEmbeddingPure(unittest.TestCase):
+    def test_build_prompt_from_dict_includes_core_fields(self):
+        vuln = {
+            "name": "SQL Injection",
+            "description": "Untrusted input reaches queries.",
+            "patterns": ["SELECT", "execute("],
+            "impact": "Data breach",
+            "mitigation": "Use parameterized queries.",
+        }
+        prompt = build_vulnerability_embedding_prompt(vuln)
+        self.assertIn("SQL Injection", prompt)
+        self.assertIn("Untrusted input reaches queries.", prompt)
+        self.assertIn("SELECT", prompt)
+        self.assertIn("Data breach", prompt)
+        self.assertIn("parameterized queries", prompt)
+
+    def test_build_prompt_from_string_is_identity(self):
+        self.assertEqual(build_vulnerability_embedding_prompt("XSS"), "XSS")
+
+    def test_generate_content_embedding_requires_manager(self):
+        with self.assertRaises(ValueError):
+            generate_content_embedding("hello", "model", ollama_manager=None)
+
+
+@unittest.skipIf(EmbeddingAnalyzer is None, "oasis.analyze dependencies are unavailable")
+class TestEmbeddingAnalyzerStats(unittest.TestCase):
+    def setUp(self):
+        self.analyzer = EmbeddingAnalyzer.__new__(EmbeddingAnalyzer)
+
+    def test_generate_threshold_analysis_empty_results(self):
+        self.assertEqual(self.analyzer.generate_threshold_analysis([]), [])
+
+    def test_generate_threshold_analysis_default_thresholds_match_config(self):
+        rows = [{"similarity_score": 0.95}, {"similarity_score": 0.25}]
+        out = self.analyzer.generate_threshold_analysis(rows)
+        self.assertEqual(len(out), len(EMBEDDING_THRESHOLDS))
+        self.assertEqual(out[0]["threshold"], EMBEDDING_THRESHOLDS[0])
+
+    def test_generate_threshold_analysis_custom_thresholds(self):
+        rows = [{"similarity_score": 0.6}]
+        out = self.analyzer.generate_threshold_analysis(rows, thresholds=[0.5, 0.9])
+        self.assertEqual(
+            out,
+            [
+                {"threshold": 0.5, "matching_items": 1, "percentage": 100.0},
+                {"threshold": 0.9, "matching_items": 0, "percentage": 0.0},
+            ],
+        )
+
+    def test_calculate_statistics_empty_results(self):
+        stats = self.analyzer.calculate_statistics([])
+        self.assertEqual(stats["avg_score"], 0)
+        self.assertEqual(stats["median_score"], 0)
+
+    def test_calculate_statistics_median_index_not_statistical_median(self):
+        """Regression guard: implementation uses sorted(scores)[len//2] (upper-middle for even n)."""
+        rows = [
+            {"similarity_score": 0.1},
+            {"similarity_score": 0.2},
+            {"similarity_score": 0.3},
+            {"similarity_score": 0.4},
+        ]
+        stats = self.analyzer.calculate_statistics(rows)
+        self.assertEqual(stats["median_score"], 0.3)
+        self.assertEqual(stats["count"], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_helpers_dashboard.py
+++ b/tests/test_helpers_dashboard.py
@@ -1,0 +1,40 @@
+"""Tests for pure dashboard helper functions."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.helpers.dashboard import dashboard_format_display_order, expand_socketio_cors_config_entries
+
+
+class TestHelpersDashboard(unittest.TestCase):
+    def test_dashboard_format_display_order_preserves_canonical_casing(self):
+        order = dashboard_format_display_order()
+        self.assertTrue(order)
+        lower_seen = set()
+        for fmt in order:
+            key = fmt.lower()
+            self.assertNotIn(key, lower_seen)
+            lower_seen.add(key)
+
+    def test_expand_socketio_cors_substitutes_port_placeholder(self):
+        expanded = expand_socketio_cors_config_entries(
+            ["http://127.0.0.1:{port}", "https://example.invalid:{port}"],
+            port=5050,
+        )
+        self.assertEqual(
+            expanded,
+            ["http://127.0.0.1:5050", "https://example.invalid:5050"],
+        )
+
+    def test_expand_socketio_cors_skips_empty_and_none(self):
+        expanded = expand_socketio_cors_config_entries(["", "http://fixed:5000"], port=9999)
+        self.assertEqual(expanded, ["http://fixed:5000"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_oasis_cli.py
+++ b/tests/test_oasis_cli.py
@@ -1,0 +1,115 @@
+"""CLI validation tests for OasisScanner (argparse helpers, argument rules)."""
+
+import argparse
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.config import REPORT
+from oasis.oasis import OasisScanner
+
+
+class TestOasisCliParsing(unittest.TestCase):
+    def test_parse_yes_no_accepts_yes_no(self):
+        self.assertTrue(OasisScanner._parse_yes_no_flag("yes"))
+        self.assertFalse(OasisScanner._parse_yes_no_flag("no"))
+        self.assertFalse(OasisScanner._parse_yes_no_flag(" NO "))
+        self.assertTrue(OasisScanner._parse_yes_no_flag("Yes"))
+
+    def test_parse_yes_no_rejects_invalid(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            OasisScanner._parse_yes_no_flag("maybe")
+
+    def test_output_format_cli_all_expands_to_canonical_list(self):
+        out = OasisScanner._output_format_cli_type("all")
+        self.assertEqual(out, list(REPORT["OUTPUT_FORMATS"]))
+
+    def test_output_format_cli_rejects_non_string(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            OasisScanner._output_format_cli_type(123)  # type: ignore[arg-type]
+
+    def test_parse_output_formats_list_rejects_unknown_token(self):
+        with self.assertRaises(ValueError) as ctx:
+            OasisScanner._parse_output_formats_list("json,not_a_real_format")
+        self.assertIn("Unknown output format", str(ctx.exception))
+
+
+class TestOasisCliInitArguments(unittest.TestCase):
+    def test_init_arguments_requires_input_path(self):
+        scanner = OasisScanner()
+        parser = scanner.setup_argument_parser()
+        namespace = parser.parse_args(["--output-format", "json"])
+        namespace.input_path = ""
+        with patch.object(scanner, "_handle_argument_errors", return_value=False) as err:
+            result = scanner._init_arguments(namespace)
+        self.assertFalse(result)
+        err.assert_called_once()
+        self.assertIn("--input", err.call_args[0][0])
+
+    def test_init_arguments_rejects_silent_without_models_or_audit(self):
+        scanner = OasisScanner()
+        parser = scanner.setup_argument_parser()
+        td = tempfile.mkdtemp()
+        try:
+            namespace = parser.parse_args(["-i", td, "-s"])
+            with patch.object(scanner, "_handle_argument_errors", return_value=False) as err:
+                result = scanner._init_arguments(namespace)
+            self.assertFalse(result)
+            err.assert_called_once()
+            self.assertIn("silent", err.call_args[0][0].lower())
+        finally:
+            shutil.rmtree(td)
+
+    def test_init_arguments_accepts_silent_with_models(self):
+        scanner = OasisScanner()
+        parser = scanner.setup_argument_parser()
+        td = tempfile.mkdtemp()
+        try:
+            namespace = parser.parse_args(["-i", td, "-s", "-m", "mistral"])
+            with patch.object(scanner, "_setup_logging"), patch(
+                "oasis.oasis.validate_report_dashboard_formats"
+            ), patch("oasis.oasis.display_logo"):
+                result = scanner._init_arguments(namespace)
+            self.assertTrue(result)
+        finally:
+            shutil.rmtree(td)
+
+    def test_init_arguments_version_returns_none(self):
+        scanner = OasisScanner()
+        parser = scanner.setup_argument_parser()
+        namespace = parser.parse_args(["--version"])
+        with patch("builtins.print") as mock_print:
+            result = scanner._init_arguments(namespace)
+        self.assertIsNone(result)
+        mock_print.assert_called_once()
+
+    def test_init_arguments_invalid_output_format_string_returns_false(self):
+        scanner = OasisScanner()
+        td = tempfile.mkdtemp()
+        try:
+            namespace = MagicMock()
+            namespace.version = False
+            namespace.list_models = False
+            namespace.silent = False
+            namespace.models = None
+            namespace.audit = False
+            namespace.input_path = td
+            namespace.output_format = "%%%invalid%%%"
+            namespace.debug = False
+            with patch.object(scanner, "_handle_argument_errors", return_value=False) as err:
+                result = scanner._init_arguments(namespace)
+            self.assertFalse(result)
+            err.assert_called_once()
+        finally:
+            shutil.rmtree(td)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ollama_manager_resilience.py
+++ b/tests/test_ollama_manager_resilience.py
@@ -1,0 +1,93 @@
+"""Resilience-oriented tests for OllamaManager (connection handling, client compatibility)."""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.ollama_manager import OllamaManager
+
+
+class TestOllamaManagerResilience(unittest.TestCase):
+    def test_get_client_raises_connection_error_when_probe_list_fails(self):
+        mgr = OllamaManager(api_url="http://127.0.0.1:11434")
+        fake_client = MagicMock()
+        fake_client.list.side_effect = RuntimeError("simulated transport failure")
+
+        with patch("oasis.ollama_manager.ollama.Client", return_value=fake_client):
+            mgr.client = None
+            with self.assertRaises(ConnectionError) as ctx:
+                mgr.get_client()
+            self.assertIn("Cannot connect to Ollama server", str(ctx.exception))
+
+    def test_check_connection_returns_false_when_probe_fails(self):
+        mgr = OllamaManager(api_url="http://127.0.0.1:11434")
+        fake_client = MagicMock()
+        fake_client.list.side_effect = ConnectionError("connection refused")
+
+        with patch("oasis.ollama_manager.ollama.Client", return_value=fake_client):
+            mgr.client = None
+            self.assertFalse(mgr.check_connection())
+
+    def test_chat_retries_without_think_when_client_rejects_think_kwarg(self):
+        mgr = OllamaManager(api_url="http://127.0.0.1:11434")
+        mgr.client = MagicMock()
+        mgr.client.chat.side_effect = [
+            TypeError("unexpected keyword argument 'think'"),
+            {"message": {"content": "ok"}},
+        ]
+        mgr.set_model_thinking("mistral", True)
+
+        out = mgr.chat("mistral", [{"role": "user", "content": "ping"}])
+
+        self.assertEqual(out, {"message": {"content": "ok"}})
+        self.assertEqual(mgr.client.chat.call_count, 2)
+        second_kw = mgr.client.chat.call_args_list[1].kwargs
+        self.assertNotIn("think", second_kw)
+
+    def test_generate_retries_without_think_when_client_rejects_think_kwarg(self):
+        mgr = OllamaManager(api_url="http://127.0.0.1:11434")
+        mgr.client = MagicMock()
+        mgr.client.generate.side_effect = [
+            TypeError("unexpected keyword argument 'think'"),
+            {"response": "done"},
+        ]
+        mgr.set_model_thinking("llama", True)
+
+        out = mgr.generate("llama", "prompt text")
+
+        self.assertEqual(out, {"response": "done"})
+        self.assertEqual(mgr.client.generate.call_count, 2)
+        self.assertNotIn("think", mgr.client.generate.call_args_list[1].kwargs)
+
+
+class TestOllamaManagerThinkingOverrides(unittest.TestCase):
+    """State-only thinking configuration (no network)."""
+
+    def test_resolve_model_thinking_returns_override(self):
+        mgr = OllamaManager(api_url="http://127.0.0.1:11434")
+        mgr.set_model_thinking("scan-model", False)
+        mgr.set_model_thinking("deep-model", True)
+        self.assertIs(mgr._resolve_model_thinking("deep-model"), True)
+        self.assertIs(mgr._resolve_model_thinking("scan-model"), False)
+        self.assertIsNone(mgr._resolve_model_thinking("unknown"))
+
+    def test_configure_analysis_model_thinking_maps_scan_and_main_models(self):
+        mgr = OllamaManager(api_url="http://127.0.0.1:11434")
+        mgr.configure_analysis_model_thinking(
+            "scanner",
+            ["deep-a", "deep-b"],
+            scan_model_thinking=False,
+            main_model_thinking=True,
+        )
+        self.assertIs(mgr._resolve_model_thinking("scanner"), False)
+        self.assertIs(mgr._resolve_model_thinking("deep-a"), True)
+        self.assertIs(mgr._resolve_model_thinking("deep-b"), True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_paths.py
+++ b/tests/test_report_paths.py
@@ -1,0 +1,31 @@
+"""Tests for small path helpers on the report module."""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+try:
+    from oasis.report import executive_summary_progress_sidecar_path
+except ImportError:
+    executive_summary_progress_sidecar_path = None
+
+
+@unittest.skipIf(
+    executive_summary_progress_sidecar_path is None,
+    "oasis.report dependencies are unavailable",
+)
+class TestReportPathHelpers(unittest.TestCase):
+    def test_executive_summary_progress_sidecar_suffix(self):
+        base = Path("/runs/m/json/_executive_summary.json")
+        sidecar = executive_summary_progress_sidecar_path(base)
+        self.assertEqual(sidecar.name, "_executive_summary.progress.json")
+        self.assertEqual(sidecar.parent, base.parent)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -566,6 +566,60 @@ class TestReportSchema(unittest.TestCase):
         self.assertEqual(progresses[-1]["status"], "succeeded")
         self.assertFalse(progresses[-1]["is_partial"])
 
+    @unittest.skipIf(publish_incremental_summary is None, "oasis.report dependencies are unavailable")
+    def test_publish_incremental_summary_passes_allowed_extended_progress_fields(self):
+        progresses: list = []
+
+        report = SimpleNamespace(
+            generate_executive_summary=lambda all_results, llm_model, progress=None: progresses.append(
+                progress
+            )
+        )
+
+        publish_incremental_summary(
+            report,
+            "model-z",
+            {"SQL Injection": []},
+            completed_vulnerabilities=1,
+            total_vulnerabilities=2,
+            current_vulnerability="sqli",
+            tested_vulnerabilities=["sqli"],
+            event_version=2,
+            vulnerability_types_total=7,
+            active_phase="deep_analysis",
+        )
+
+        payload = progresses[-1]
+        self.assertEqual(payload["event_version"], 2)
+        self.assertEqual(payload["vulnerability_types_total"], 7)
+        self.assertEqual(payload["active_phase"], "deep_analysis")
+
+    def test_sanitize_name_strips_path_suffix_and_special_characters(self):
+        from oasis.tools import sanitize_name
+
+        self.assertEqual(sanitize_name("group/sub/Vuln Name!.md"), "Vuln_Name__md")
+
+    @unittest.skipIf(
+        WebServer is None or Report is None,
+        "oasis.web or oasis.report dependencies are unavailable",
+    )
+    def test_web_get_report_statistics_empty_filtered_list(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            inp = base / "scan_root"
+            inp.mkdir()
+            (inp / "module.py").write_text("#", encoding="utf-8")
+            report = Report(str(inp), ["json"])
+            server = WebServer(report)
+            server.report_data = []
+            server.collect_report_data = lambda: None
+            app = Flask(__name__)
+            with app.test_request_context("/api/stats"):
+                stats = server.get_report_statistics(filtered_reports=[])
+
+        self.assertEqual(stats.get("formats"), {})
+        self.assertEqual(stats["risk_summary"]["total_findings"], 0)
+
     @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
     def test_executive_summary_notifier_receives_progress_payload(self):
         report = Report.__new__(Report)
@@ -650,6 +704,48 @@ class TestReportSchema(unittest.TestCase):
             report_file.write_text('{"stats":', encoding="utf-8")
             stats = WebServer._stats_from_json_report_file(report_file)
         self.assertEqual(stats, {})
+
+    @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
+    def test_web_update_stats_for_report_aggregates_model_vuln_language_date_and_risk(self):
+        server = WebServer.__new__(WebServer)
+        stats = {
+            "total_reports": 0,
+            "models": {},
+            "vulnerabilities": {},
+            "languages": {},
+            "dates": {},
+            "risk_summary": {
+                "total_findings": 0,
+                "high": 0,
+                "medium": 0,
+                "low": 0,
+            },
+        }
+        server._update_stats_for_report(
+            stats,
+            {
+                "format": "json",
+                "model": "ModelA",
+                "vulnerability_type": "SQL Injection",
+                "language": "FR",
+                "date": "2026-04-19 10:00:00",
+                "stats": {
+                    "total_findings": 5,
+                    "high_risk": 2,
+                    "medium_risk": 2,
+                    "low_risk": 1,
+                },
+            },
+        )
+        self.assertEqual(stats["total_reports"], 1)
+        self.assertEqual(stats["models"]["ModelA"], 1)
+        self.assertEqual(stats["vulnerabilities"]["SQL Injection"], 1)
+        self.assertEqual(stats["languages"]["fr"], 1)
+        self.assertEqual(stats["dates"]["2026-04-19"], 1)
+        self.assertEqual(stats["risk_summary"]["total_findings"], 5)
+        self.assertEqual(stats["risk_summary"]["high"], 2)
+        self.assertEqual(stats["risk_summary"]["medium"], 2)
+        self.assertEqual(stats["risk_summary"]["low"], 1)
 
     @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
     def test_web_summary_progress_reader_extracts_partial_status(self):

--- a/tests/test_structured_output_parsing.py
+++ b/tests/test_structured_output_parsing.py
@@ -14,7 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 try:
-    from oasis.schemas.analysis import ChunkDeepAnalysis
+    from oasis.schemas.analysis import ChunkDeepAnalysis, ScanVerdict
 except ModuleNotFoundError:
     _spec = importlib.util.spec_from_file_location(
         "oasis_schemas_analysis",
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
     assert _spec and _spec.loader is not None
     _spec.loader.exec_module(_analysis)
     ChunkDeepAnalysis = _analysis.ChunkDeepAnalysis
+    ScanVerdict = _analysis.ScanVerdict
 
 try:
     from oasis.structured_output.deep import (
@@ -418,6 +419,76 @@ class TestStructuredOutputParsing(unittest.TestCase):
         )
         parsed = ChunkDeepAnalysis.model_validate_json(repaired)
         self.assertEqual(parsed.notes, r"bad \x escape")
+
+    def test_structured_failure_handler_overrides_default_chunk_deep(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.run_id = None
+
+        def handler(_response_model, _raw, _error, _model_display):
+            return ChunkDeepAnalysis(
+                findings=[],
+                notes="handler-override",
+                validation_error=True,
+            ).model_dump_json()
+
+        analyzer.structured_output_failure_handler = handler
+        # Valid JSON but wrong type for ``findings`` — not a JSON-syntax repair case.
+        out = analyzer._parse_structured_output_response(
+            raw='{"findings":"not-a-list","notes":"n"}',
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = json.loads(out)
+        self.assertEqual(parsed["notes"], "handler-override")
+        self.assertTrue(parsed.get("validation_error"))
+
+    def test_structured_failure_handler_none_uses_default_chunk_deep(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.run_id = None
+        analyzer.structured_output_failure_handler = None
+        out = analyzer._parse_structured_output_response(
+            raw='{"findings":"not-a-list","notes":"n"}',
+            response_model=ChunkDeepAnalysis,
+            model_display="test-model",
+        )
+        parsed = json.loads(out)
+        self.assertTrue(parsed.get("validation_error"))
+        self.assertIn("Structured output failure", parsed["notes"])
+
+    def test_parse_structured_output_response_raises_when_raise_validation_error_true(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        analyzer.run_id = None
+        analyzer.structured_output_failure_handler = None
+        with self.assertRaises(ValidationError):
+            analyzer._parse_structured_output_response(
+                raw='{"findings":"not-a-list","notes":"n"}',
+                response_model=ChunkDeepAnalysis,
+                model_display="test-model",
+                raise_validation_error=True,
+            )
+
+    def test_default_structured_output_failure_scan_verdict_returns_error_token(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+        out = analyzer._default_structured_output_failure(
+            ScanVerdict,
+            ValueError("broken"),
+        )
+        self.assertEqual(out, "ERROR")
+
+    def test_resolve_structured_output_failure_delegates_to_handler(self):
+        analyzer = SecurityAnalyzer.__new__(SecurityAnalyzer)
+
+        def handler(_rm, _raw, _err, _md):
+            return '{"findings":[],"notes":"resolved"}'
+
+        analyzer.structured_output_failure_handler = handler
+        out = analyzer._resolve_structured_output_failure(
+            ChunkDeepAnalysis,
+            raw='{"broken"',
+            error=ValueError("simulated"),
+            model_display="m",
+        )
+        self.assertEqual(json.loads(out)["notes"], "resolved")
 
 
 if __name__ == "__main__":

--- a/tests/test_tools_parse_input.py
+++ b/tests/test_tools_parse_input.py
@@ -1,0 +1,65 @@
+"""Tests for tools.parse_input and related path helpers."""
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from oasis.tools import calculate_similarity, extract_clean_path, parse_input
+
+
+class TestCalculateSimilarity(unittest.TestCase):
+    def test_zero_norm_returns_zero(self):
+        self.assertEqual(calculate_similarity([0.0, 0.0], [1.0, 0.0]), 0.0)
+        self.assertEqual(calculate_similarity([1.0, 0.0], [0.0, 0.0]), 0.0)
+
+    def test_identical_vectors_cosine_one(self):
+        self.assertAlmostEqual(calculate_similarity([1.0, 2.0], [1.0, 2.0]), 1.0, places=5)
+
+
+class TestParseInput(unittest.TestCase):
+    def test_single_file_returns_one_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "sample.py"
+            p.write_text("print(1)", encoding="utf-8")
+            files = parse_input(str(p))
+            self.assertEqual(files, [p.resolve()])
+
+    def test_directory_collects_files_recursively(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            sub = root / "pkg"
+            sub.mkdir()
+            a = root / "a.py"
+            b = sub / "b.js"
+            a.write_text("#", encoding="utf-8")
+            b.write_text("//", encoding="utf-8")
+            files = parse_input(str(root))
+            resolved = {f.resolve() for f in files}
+            self.assertEqual(resolved, {a.resolve(), b.resolve()})
+
+    def test_txt_manifest_lists_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            target = root / "listed.py"
+            target.write_text("x", encoding="utf-8")
+            manifest = root / "paths.txt"
+            manifest.write_text(str(target) + "\n", encoding="utf-8")
+            files = parse_input(str(manifest))
+            self.assertEqual(files, [target.resolve()])
+
+
+class TestExtractCleanPath(unittest.TestCase):
+    def test_strips_inline_comment_after_space(self):
+        raw = "/tmp/project/app.py extra-args"
+        clean = extract_clean_path(raw)
+        self.assertEqual(Path(clean), Path("/tmp/project/app.py"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add an optional development coverage dependency and broaden test coverage for analysis orchestration, structured output handling, CLI behavior, caching, embedding, tools utilities, web reporting, Ollama client resilience, and report/dashboard helpers.

Build:
- Declare a `dev` optional dependency group in `pyproject.toml` providing `coverage` for local test coverage reporting.

Tests:
- Add extensive new unit tests covering SecurityAnalyzer orchestration and embedding similarity paths, CLI parsing and argument validation, caching behavior, embedding helpers and statistics, tools input parsing and similarity calculations, structured output failure handling, web reporting statistics, OllamaManager resilience and thinking overrides, and report/dashboard path and formatting helpers.