### PR TITLE
feat(cli): add update check and self-update options to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - 🌍 Added report language metadata (`language`) in canonical JSON and dashboard language flags sourced from report data
 - 🌐 Added dashboard language filter with emoji-flag display aligned with report language badges
 - 🧭 Added `.cursor/` rules and agent skills for implementation, releases, and git conventions
+- 📦 **CLI updates from GitHub releases** (no PyPI): **`--check-update`** compares the installed version to the **latest stable** release via the GitHub API (**draft** and **prerelease** releases are ignored); **`--self-update`** reinstalls from `git+https://github.com/psyray/oasis.git@<tag>` using **pipx** when the package is installed under **site-packages** (editable/dev installs get `git pull` guidance). Optional **stderr** notice when a newer stable release exists, with **24 h** on-disk cache under `XDG_CACHE_HOME` / `~/.cache/oasis/`; set **`OASIS_NO_UPDATE_CHECK=1`** to disable. Adds **`packaging`** as a declared runtime dependency for version ordering
 
 ### 🐛 Fixed
 - 🔧 Fixed **`--embeddings-analyze-type`** default: was incorrectly tied to the removed analyze-type default; default is now **`file`** (`EMBEDDING_ANALYSIS_TYPE`)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,16 @@ Code is mounted at **`/work`**; use `-i` paths under `/work`. More options (bund
 
 ### Maintenance
 
-**Update** — after `git pull`, your editable pipx install tracks the repo; bump metadata if needed:
+**Update from GitHub releases** (recommended when you installed from tags / non-editable):
+
+```bash
+oasis --check-update   # compare installed version vs latest stable release on GitHub
+oasis --self-update    # reinstall latest stable via pipx (requires pipx on PATH)
+```
+
+Stable releases only: GitHub entries marked pre-release are ignored. To skip the occasional “update available” line on stderr, set `OASIS_NO_UPDATE_CHECK=1`. For unexpected banner failures, set `OASIS_DEBUG_UPDATE` to `1`, `true`, or `yes` to print a short diagnostic on stderr (developer troubleshooting).
+
+**Editable / development clone** — after `git pull`, your editable pipx install tracks the repo:
 
 ```bash
 git pull origin master

--- a/oasis/helpers/assistant_think_parse.py
+++ b/oasis/helpers/assistant_think_parse.py
@@ -19,9 +19,14 @@ class AssistantThinkSplit:
     thought_segments: List[str]
 
 
-# Matches ``<|channel>thought <channel|>`` then body until ``\\n\\n`` (reply) or EOS.
+# Open: ``<|channel>`` + one or more ``thought`` tokens; close: ``<channel|>`` or ``<|channel|>``
+# (provider output varies; some models repeat ``thought`` or use a symmetric close tag).
 _CHANNEL_THOUGHT_OPEN = re.compile(
-    r"<\|channel>\s*thought\s*<\s*channel\s*\|\s*>",
+    r"<\|channel>\s*(?:thought\s*)+"
+    r"(?:"
+    r"<\s*channel\s*\|>"  # e.g. <channel|>
+    r"|<\s*\|channel\|>"  # e.g. <|channel|>
+    r")",
     re.IGNORECASE,
 )
 
@@ -38,18 +43,34 @@ _THINK_BLOCK_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 
 def _strip_channel_thought_prefix(work: str, segments: List[str]) -> str:
-    """Extract ``<|channel>thought <channel|>…`` blocks; optional ``\\n\\n`` splits thought vs reply."""
+    """Extract ``<|channel>thought … <|channel|>`` segments.
+
+    End of segment: next channel opener if any (handles multiple reasoning blocks back-to-back),
+    else first ``\\n\\n`` (thought vs reply), else end of string.
+    """
     while True:
         m = _CHANNEL_THOUGHT_OPEN.search(work)
         if not m:
             return work
+        before = work[: m.start()]
         tail = work[m.end() :]
-        parts = tail.split("\n\n", 1)
-        thought_body = parts[0].strip()
-        visible_rest = parts[1].strip() if len(parts) > 1 else ""
+        next_open = _CHANNEL_THOUGHT_OPEN.search(tail)
+        para_idx = tail.find("\n\n")
+
+        if next_open is not None:
+            end = next_open.start()
+            thought_body = tail[:end].strip()
+            # Keep remainder starting at the next opener so the outer loop extracts it too.
+            work = before + tail[end:]
+        elif para_idx != -1:
+            thought_body = tail[:para_idx].strip()
+            work = before + tail[para_idx + 2 :]
+        else:
+            thought_body = tail.strip()
+            work = before
+
         if thought_body:
             segments.append(thought_body)
-        work = work[: m.start()] + visible_rest
 
 
 def parse_assistant_think(text: str) -> AssistantThinkSplit:

--- a/oasis/helpers/assistant_think_parse.py
+++ b/oasis/helpers/assistant_think_parse.py
@@ -57,7 +57,7 @@ def _strip_channel_thought_prefix(work: str, segments: List[str]) -> str:
         next_open = _CHANNEL_THOUGHT_OPEN.search(tail)
         para_idx = tail.find("\n\n")
 
-        if next_open is not None:
+        if next_open is not None and (para_idx == -1 or next_open.start() < para_idx):
             end = next_open.start()
             thought_body = tail[:end].strip()
             # Keep remainder starting at the next opener so the outer loop extracts it too.

--- a/oasis/helpers/cli_update.py
+++ b/oasis/helpers/cli_update.py
@@ -46,6 +46,15 @@ class StableRelease:
     published_at: str
 
 
+@dataclass(frozen=True)
+class UpdateStatus:
+    """Normalized local/latest status for CLI update actions."""
+
+    local: Optional[Version]
+    latest: Optional[StableRelease]
+    error: Optional[str] = None
+
+
 def _user_agent() -> str:
     try:
         ver = installed_version_string()
@@ -77,94 +86,39 @@ def version_from_tag_name(tag_name: str) -> Optional[Version]:
         return None
 
 
-def _iter_site_package_roots() -> list[Path]:
-    """Return candidate site-packages root directories as resolved Paths."""
-    roots: set[Path] = set()
+def is_site_packages_install() -> bool:
+    """True when ``oasis`` is loaded from interpreter site-packages roots."""
+    import oasis
 
+    src = getattr(oasis, "__file__", None)
+    if not src:
+        return False
     try:
-        cfg_paths = sysconfig.get_paths()
-        for key in ("purelib", "platlib"):
-            p = cfg_paths.get(key)
-            if p:
-                roots.add(Path(p))
-    except (KeyError, TypeError, OSError):
-        pass
-
-    try:
-        import site
-
-        gs = getattr(site, "getsitepackages", None)
-        if callable(gs):
-            for p in gs() or []:
-                roots.add(Path(p))
-        gu = getattr(site, "getusersitepackages", None)
-        if callable(gu):
-            user_site = gu()
-            if user_site:
-                roots.add(Path(user_site))
-    except Exception:
-        pass
-
-    for entry in sys.path:
-        if not entry:
-            continue
-        p = Path(entry)
-        name = p.name.lower()
-        if "site-packages" in name or "dist-packages" in name:
-            roots.add(p)
-
-    normalized: list[Path] = []
-    for r in roots:
-        try:
-            normalized.append(r.resolve())
-        except OSError:
-            normalized.append(r)
-    return normalized
-
-
-def _is_under_any(path: Path, roots: list[Path]) -> bool:
-    """Return True if ``path`` is located under any of the given ``roots``."""
-    try:
-        path = path.resolve()
+        pkg_path = Path(src).resolve()
     except OSError:
-        pass
+        pkg_path = Path(src)
 
-    for root in roots:
+    try:
+        purelib = Path(sysconfig.get_path("purelib")).resolve()
+        platlib = Path(sysconfig.get_path("platlib")).resolve()
+    except (TypeError, KeyError, OSError):
         try:
-            root_resolved = root.resolve()
+            prefix = Path(sys.prefix).resolve()
         except OSError:
-            root_resolved = root
-
+            prefix = Path(sys.prefix)
         try:
-            path.relative_to(root_resolved)
+            pkg_path.relative_to(prefix)
+            return True
+        except ValueError:
+            return False
+
+    for root in (purelib, platlib):
+        try:
+            pkg_path.relative_to(root)
             return True
         except ValueError:
             continue
     return False
-
-
-def is_site_packages_install() -> bool:
-    """True when ``oasis`` is loaded from a recognized site-packages root (sysconfig/site/sys.path)."""
-    import oasis
-
-    pkg_paths = getattr(oasis, "__path__", None)
-    pkg_path: Path
-    if pkg_paths:
-        try:
-            pkg_path = Path(next(iter(pkg_paths)))
-        except StopIteration:
-            src = getattr(oasis, "__file__", None)
-            if not src:
-                return False
-            pkg_path = Path(src)
-    else:
-        src = getattr(oasis, "__file__", None)
-        if not src:
-            return False
-        pkg_path = Path(src)
-
-    roots = _iter_site_package_roots()
-    return _is_under_any(pkg_path, roots)
 
 
 def _cache_base_dir() -> Path:
@@ -254,30 +208,29 @@ def fetch_latest_stable_release(
             client.close()
 
 
-def resolve_latest_stable_for_notice(
+def get_latest_stable_release(
     *,
-    force_refresh: bool,
+    use_cache: bool,
     client: Optional[httpx.Client] = None,
+    timeout_sec: float = 12.0,
 ) -> tuple[Optional[StableRelease], bool]:
-    """
-    Return (release, used_network). Uses disk cache when fresh unless force_refresh.
-    """
+    """Return (release, used_network), with optional cache read/write."""
     now = time.time()
-    cached = None if force_refresh else _read_cache()
-    if cached:
-        try:
-            ts = float(cached.get("checked_at_epoch", 0))
-            tag = cached.get("tag_name")
-            ver_s = cached.get("latest_version")
-            if tag and ver_s and (now - ts) <= CACHE_TTL_SECONDS:
-                ver = Version(ver_s)
-                pub = str(cached.get("published_at", ""))
-                return StableRelease(tag_name=str(tag), version=ver, published_at=pub), False
-        except (InvalidVersion, TypeError, ValueError):
-            pass
+    if use_cache:
+        cached = _read_cache()
+        if cached:
+            try:
+                ts = float(cached.get("checked_at_epoch", 0))
+                if (now - ts) <= CACHE_TTL_SECONDS:
+                    tag = str(cached["tag_name"])
+                    ver = Version(str(cached["latest_version"]))
+                    pub = str(cached.get("published_at", ""))
+                    return StableRelease(tag_name=tag, version=ver, published_at=pub), False
+            except (KeyError, InvalidVersion, TypeError, ValueError):
+                pass
 
-    latest = fetch_latest_stable_release(client=client)
-    if latest is not None:
+    latest = fetch_latest_stable_release(client=client, timeout_sec=timeout_sec)
+    if latest is not None and use_cache:
         _write_cache(
             {
                 "checked_at_epoch": now,
@@ -287,6 +240,52 @@ def resolve_latest_stable_for_notice(
             }
         )
     return latest, True
+
+
+def resolve_latest_stable_for_notice(
+    *,
+    force_refresh: bool,
+    client: Optional[httpx.Client] = None,
+) -> tuple[Optional[StableRelease], bool]:
+    """Backward-compatible wrapper for notice resolution semantics."""
+    if force_refresh:
+        latest, used_network = get_latest_stable_release(
+            use_cache=False,
+            client=client,
+        )
+        if latest is not None:
+            _write_cache(
+                {
+                    "checked_at_epoch": time.time(),
+                    "tag_name": latest.tag_name,
+                    "latest_version": str(latest.version),
+                    "published_at": latest.published_at,
+                }
+            )
+        return latest, used_network
+
+    return get_latest_stable_release(use_cache=True, client=client)
+
+
+def get_update_status(*, use_cache: bool) -> UpdateStatus:
+    """Build local/latest update status with shared parse and error handling."""
+    try:
+        local_v = Version(installed_version_string())
+    except InvalidVersion:
+        return UpdateStatus(
+            local=None,
+            latest=None,
+            error="Could not parse installed version.",
+        )
+
+    latest, _ = get_latest_stable_release(use_cache=use_cache)
+    if latest is None:
+        return UpdateStatus(
+            local=local_v,
+            latest=None,
+            error="Could not determine the latest stable release (network or GitHub API).",
+        )
+    return UpdateStatus(local=local_v, latest=latest)
 
 
 def _log_update_banner_error(exc: BaseException) -> None:
@@ -308,13 +307,14 @@ def maybe_emit_update_banner(*, silent: bool) -> None:
     if os.environ.get(ENV_DISABLE_CHECK):
         return
     try:
-        local = Version(installed_version_string())
-        latest, _ = resolve_latest_stable_for_notice(force_refresh=False)
-        if latest is None or latest.version <= local:
+        status = get_update_status(use_cache=True)
+        if status.error or status.local is None or status.latest is None:
             return
-        pip_ref = f"git+{GIT_REMOTE_INSTALL_URL}@{latest.tag_name}"
+        if status.latest.version <= status.local:
+            return
+        pip_ref = f"git+{GIT_REMOTE_INSTALL_URL}@{status.latest.tag_name}"
         print(
-            f"oasis: update available ({local} -> {latest.version}). "
+            f"oasis: update available ({status.local} -> {status.latest.version}). "
             f"Run: pipx install --force {pip_ref}",
             file=sys.stderr,
         )
@@ -326,25 +326,16 @@ def maybe_emit_update_banner(*, silent: bool) -> None:
 
 def print_check_update() -> int:
     """Print local vs latest stable from GitHub; stdout user text, non-zero on hard errors."""
-    try:
-        local_v = Version(installed_version_string())
-    except InvalidVersion:
-        print("Could not parse installed version.", file=sys.stderr)
+    status = get_update_status(use_cache=False)
+    if status.error or status.local is None or status.latest is None:
+        print(status.error or "Could not determine update status.", file=sys.stderr)
         return 1
 
-    latest = fetch_latest_stable_release()
-    if latest is None:
-        print(
-            "Could not determine the latest stable release (network or GitHub API).",
-            file=sys.stderr,
-        )
-        return 1
+    print(f"Current version: {status.local}")
+    print(f"Latest stable:   {status.latest.version} ({status.latest.tag_name})")
 
-    print(f"Current version: {local_v}")
-    print(f"Latest stable:   {latest.version} ({latest.tag_name})")
-
-    if latest.version > local_v:
-        pip_ref = f"git+{GIT_REMOTE_INSTALL_URL}@{latest.tag_name}"
+    if status.latest.version > status.local:
+        pip_ref = f"git+{GIT_REMOTE_INSTALL_URL}@{status.latest.tag_name}"
         print("Update available. Run: oasis --self-update")
         print(f"Or: pipx install --force {pip_ref}")
         return 0
@@ -363,25 +354,16 @@ def run_self_update() -> int:
         )
         return 1
 
-    try:
-        local_v = Version(installed_version_string())
-    except InvalidVersion:
-        print("Could not parse installed version.", file=sys.stderr)
+    status = get_update_status(use_cache=False)
+    if status.error or status.local is None or status.latest is None:
+        print(status.error or "Could not determine update status.", file=sys.stderr)
         return 1
 
-    latest = fetch_latest_stable_release()
-    if latest is None:
-        print(
-            "Could not determine the latest stable release (network or GitHub API).",
-            file=sys.stderr,
-        )
-        return 1
-
-    if latest.version <= local_v:
-        print(f"Already up to date ({local_v}).")
+    if status.latest.version <= status.local:
+        print(f"Already up to date ({status.local}).")
         return 0
 
-    pip_url = f"git+{GIT_REMOTE_INSTALL_URL}@{latest.tag_name}"
+    pip_url = f"git+{GIT_REMOTE_INSTALL_URL}@{status.latest.tag_name}"
 
     pipx_exe = shutil.which("pipx")
     if pipx_exe is None:
@@ -393,7 +375,8 @@ def run_self_update() -> int:
         return 1
 
     cmd = [pipx_exe, "install", "--force", pip_url]
-    print(f"Upgrading to {latest.tag_name} ({latest.version}) …")
-    proc = subprocess.run(cmd)
+    print(f"Upgrading to {status.latest.tag_name} ({status.latest.version}) …")
+    # Safe: shell=False and args list; no shell interpolation occurs.
+    proc = subprocess.run(cmd, shell=False)  # nosec B603
     return int(proc.returncode)
 

--- a/oasis/helpers/cli_update.py
+++ b/oasis/helpers/cli_update.py
@@ -1,0 +1,399 @@
+"""
+GitHub release metadata and optional CLI self-update for OASIS (no PyPI).
+
+Stable releases only: GitHub entries with draft or prerelease set are ignored.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+from packaging.version import InvalidVersion, Version
+
+logger = logging.getLogger(__name__)
+
+GITHUB_OWNER = "psyray"
+GITHUB_REPO = "oasis"
+RELEASES_API_URL = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases"
+GIT_REMOTE_INSTALL_URL = "https://github.com/psyray/oasis.git"
+
+CACHE_SUBDIR = "oasis"
+CACHE_FILENAME = "update_check.json"
+CACHE_TTL_SECONDS = 24 * 3600
+
+ENV_DISABLE_CHECK = "OASIS_NO_UPDATE_CHECK"
+ENV_DEBUG_UPDATE_BANNER = "OASIS_DEBUG_UPDATE"
+
+
+@dataclass(frozen=True)
+class StableRelease:
+    """Latest non-draft, non-prerelease GitHub release."""
+
+    tag_name: str
+    version: Version
+    published_at: str
+
+
+def _user_agent() -> str:
+    try:
+        ver = installed_version_string()
+    except Exception:
+        ver = "unknown"
+    return f"oasis/{ver} (+https://github.com/{GITHUB_OWNER}/{GITHUB_REPO})"
+
+
+def installed_version_string() -> str:
+    """Installed distribution version (metadata) or embedded ``__version__``."""
+    try:
+        return importlib.metadata.version("oasis")
+    except importlib.metadata.PackageNotFoundError:
+        from oasis import __version__
+
+        return str(__version__)
+
+
+def version_from_tag_name(tag_name: str) -> Optional[Version]:
+    """Parse a PEP 440 version from a release tag (leading ``v`` stripped when typical)."""
+    raw = (tag_name or "").strip()
+    if not raw:
+        return None
+    if len(raw) > 1 and raw[0].lower() == "v" and raw[1].isdigit():
+        raw = raw[1:]
+    try:
+        return Version(raw)
+    except InvalidVersion:
+        return None
+
+
+def _iter_site_package_roots() -> list[Path]:
+    """Return candidate site-packages root directories as resolved Paths."""
+    roots: set[Path] = set()
+
+    try:
+        cfg_paths = sysconfig.get_paths()
+        for key in ("purelib", "platlib"):
+            p = cfg_paths.get(key)
+            if p:
+                roots.add(Path(p))
+    except (KeyError, TypeError, OSError):
+        pass
+
+    try:
+        import site
+
+        gs = getattr(site, "getsitepackages", None)
+        if callable(gs):
+            for p in gs() or []:
+                roots.add(Path(p))
+        gu = getattr(site, "getusersitepackages", None)
+        if callable(gu):
+            user_site = gu()
+            if user_site:
+                roots.add(Path(user_site))
+    except Exception:
+        pass
+
+    for entry in sys.path:
+        if not entry:
+            continue
+        p = Path(entry)
+        name = p.name.lower()
+        if "site-packages" in name or "dist-packages" in name:
+            roots.add(p)
+
+    normalized: list[Path] = []
+    for r in roots:
+        try:
+            normalized.append(r.resolve())
+        except OSError:
+            normalized.append(r)
+    return normalized
+
+
+def _is_under_any(path: Path, roots: list[Path]) -> bool:
+    """Return True if ``path`` is located under any of the given ``roots``."""
+    try:
+        path = path.resolve()
+    except OSError:
+        pass
+
+    for root in roots:
+        try:
+            root_resolved = root.resolve()
+        except OSError:
+            root_resolved = root
+
+        try:
+            path.relative_to(root_resolved)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def is_site_packages_install() -> bool:
+    """True when ``oasis`` is loaded from a recognized site-packages root (sysconfig/site/sys.path)."""
+    import oasis
+
+    pkg_paths = getattr(oasis, "__path__", None)
+    pkg_path: Path
+    if pkg_paths:
+        try:
+            pkg_path = Path(next(iter(pkg_paths)))
+        except StopIteration:
+            src = getattr(oasis, "__file__", None)
+            if not src:
+                return False
+            pkg_path = Path(src)
+    else:
+        src = getattr(oasis, "__file__", None)
+        if not src:
+            return False
+        pkg_path = Path(src)
+
+    roots = _iter_site_package_roots()
+    return _is_under_any(pkg_path, roots)
+
+
+def _cache_base_dir() -> Path:
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg) / CACHE_SUBDIR
+    return Path.home() / ".cache" / CACHE_SUBDIR
+
+
+def cache_file_path() -> Path:
+    return _cache_base_dir() / CACHE_FILENAME
+
+
+def _read_cache() -> Optional[dict[str, Any]]:
+    path = cache_file_path()
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_cache(payload: dict[str, Any]) -> None:
+    path = cache_file_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Failed to write CLI update cache at %s: %s", path, exc)
+
+
+def pick_latest_stable_release(releases: list[dict[str, Any]]) -> Optional[StableRelease]:
+    """
+    Choose the newest stable release by ``published_at`` (ISO-8601), excluding draft/prerelease.
+    """
+    candidates: list[tuple[str, StableRelease]] = []
+    for rel in releases:
+        if not isinstance(rel, dict):
+            continue
+        if rel.get("draft"):
+            continue
+        if rel.get("prerelease"):
+            continue
+        tag = rel.get("tag_name")
+        if not tag or not isinstance(tag, str):
+            continue
+        pub = rel.get("published_at")
+        if not pub or not isinstance(pub, str):
+            continue
+        ver = version_from_tag_name(tag)
+        if ver is None:
+            continue
+        candidates.append(
+            (pub, StableRelease(tag_name=tag, version=ver, published_at=pub))
+        )
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return candidates[0][1]
+
+
+def fetch_latest_stable_release(
+    *,
+    client: Optional[httpx.Client] = None,
+    timeout_sec: float = 12.0,
+) -> Optional[StableRelease]:
+    """
+    GET GitHub releases (first page), return newest stable release or None on failure/empty.
+    """
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=timeout_sec, follow_redirects=True)
+    try:
+        headers = {"Accept": "application/vnd.github+json", "User-Agent": _user_agent()}
+        response = client.get(RELEASES_API_URL, params={"per_page": 100}, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, list):
+            return None
+        return pick_latest_stable_release(data)
+    except (httpx.HTTPError, ValueError, TypeError):
+        return None
+    finally:
+        if owns_client:
+            client.close()
+
+
+def resolve_latest_stable_for_notice(
+    *,
+    force_refresh: bool,
+    client: Optional[httpx.Client] = None,
+) -> tuple[Optional[StableRelease], bool]:
+    """
+    Return (release, used_network). Uses disk cache when fresh unless force_refresh.
+    """
+    now = time.time()
+    cached = None if force_refresh else _read_cache()
+    if cached:
+        try:
+            ts = float(cached.get("checked_at_epoch", 0))
+            tag = cached.get("tag_name")
+            ver_s = cached.get("latest_version")
+            if tag and ver_s and (now - ts) <= CACHE_TTL_SECONDS:
+                ver = Version(ver_s)
+                pub = str(cached.get("published_at", ""))
+                return StableRelease(tag_name=str(tag), version=ver, published_at=pub), False
+        except (InvalidVersion, TypeError, ValueError):
+            pass
+
+    latest = fetch_latest_stable_release(client=client)
+    if latest is not None:
+        _write_cache(
+            {
+                "checked_at_epoch": now,
+                "tag_name": latest.tag_name,
+                "latest_version": str(latest.version),
+                "published_at": latest.published_at,
+            }
+        )
+    return latest, True
+
+
+def _log_update_banner_error(exc: BaseException) -> None:
+    """Best-effort logging of unexpected errors during update-banner emission."""
+    raw = os.environ.get(ENV_DEBUG_UPDATE_BANNER, "")
+    debug = raw.lower() in {"1", "true", "yes"}
+    if not debug:
+        return
+    print(
+        f"oasis: update-banner error: {type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
+
+
+def maybe_emit_update_banner(*, silent: bool) -> None:
+    """Non-fatal stderr one-liner when a newer stable release exists."""
+    if silent:
+        return
+    if os.environ.get(ENV_DISABLE_CHECK):
+        return
+    try:
+        local = Version(installed_version_string())
+        latest, _ = resolve_latest_stable_for_notice(force_refresh=False)
+        if latest is None or latest.version <= local:
+            return
+        pip_ref = f"git+{GIT_REMOTE_INSTALL_URL}@{latest.tag_name}"
+        print(
+            f"oasis: update available ({local} -> {latest.version}). "
+            f"Run: pipx install --force {pip_ref}",
+            file=sys.stderr,
+        )
+    except (InvalidVersion, ValueError, OSError, TypeError, httpx.HTTPError):
+        return
+    except Exception as exc:
+        _log_update_banner_error(exc)
+
+
+def print_check_update() -> int:
+    """Print local vs latest stable from GitHub; stdout user text, non-zero on hard errors."""
+    try:
+        local_v = Version(installed_version_string())
+    except InvalidVersion:
+        print("Could not parse installed version.", file=sys.stderr)
+        return 1
+
+    latest = fetch_latest_stable_release()
+    if latest is None:
+        print(
+            "Could not determine the latest stable release (network or GitHub API).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Current version: {local_v}")
+    print(f"Latest stable:   {latest.version} ({latest.tag_name})")
+
+    if latest.version > local_v:
+        pip_ref = f"git+{GIT_REMOTE_INSTALL_URL}@{latest.tag_name}"
+        print("Update available. Run: oasis --self-update")
+        print(f"Or: pipx install --force {pip_ref}")
+        return 0
+
+    print("Up to date.")
+    return 0
+
+
+def run_self_update() -> int:
+    """Install the latest stable tag via pipx (``git+https``), if available."""
+    if not is_site_packages_install():
+        print(
+            "This install is not a normal site-packages install (likely editable/dev). "
+            "Update from your Git clone with: git pull",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        local_v = Version(installed_version_string())
+    except InvalidVersion:
+        print("Could not parse installed version.", file=sys.stderr)
+        return 1
+
+    latest = fetch_latest_stable_release()
+    if latest is None:
+        print(
+            "Could not determine the latest stable release (network or GitHub API).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if latest.version <= local_v:
+        print(f"Already up to date ({local_v}).")
+        return 0
+
+    pip_url = f"git+{GIT_REMOTE_INSTALL_URL}@{latest.tag_name}"
+
+    pipx_exe = shutil.which("pipx")
+    if pipx_exe is None:
+        print(
+            "pipx not found on PATH. Install pipx or run manually:\n"
+            f"  pip install --upgrade \"oasis @ {pip_url}\"",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd = [pipx_exe, "install", "--force", pip_url]
+    print(f"Upgrading to {latest.tag_name} ({latest.version}) …")
+    proc = subprocess.run(cmd)
+    return int(proc.returncode)
+

--- a/oasis/oasis.py
+++ b/oasis/oasis.py
@@ -48,6 +48,7 @@ class OasisScanner:
         self.embed_models = [DEFAULT_ARGS["EMBED_MODEL"]]
         self.primary_embed_model = DEFAULT_ARGS["EMBED_MODEL"]
         self.chunk_size_is_manual = False
+        self._pending_exit_code = None
 
     @staticmethod
     def _parse_embed_models_csv(value: str) -> list[str]:
@@ -438,7 +439,20 @@ class OasisScanner:
                                 help='Ollama URL (default: http://localhost:11434)')
         special_group.add_argument('-V', '--version', action='store_true',
                                 help='Show OASIS version and exit')
-        
+        update_group = special_group.add_mutually_exclusive_group()
+        update_group.add_argument(
+            '--check-update',
+            dest='check_update',
+            action='store_true',
+            help='Compare this install to the latest stable GitHub release and exit',
+        )
+        update_group.add_argument(
+            '--self-update',
+            dest='self_update',
+            action='store_true',
+            help='Upgrade from the latest stable GitHub release (requires pipx on PATH)',
+        )
+
         return parser
 
     _REMOVED_LEGACY_ANALYSIS_FLAGS = frozenset({"--adaptive", "-ad", "--analyze-type", "-at"})
@@ -669,6 +683,9 @@ class OasisScanner:
         # Parse and validate arguments
         init_result = self._init_arguments(args)
 
+        if self._pending_exit_code is not None:
+            return int(self._pending_exit_code)
+
         # Handle special early termination cases
         if init_result is None:
             return 0  # Success exit code for commands like --list-models
@@ -759,6 +776,22 @@ class OasisScanner:
             from .__init__ import __version__
             print(f"OASIS - Ollama Automated Security Intelligence Scanner v{__version__}")
             return None
+
+        if getattr(self.args, "check_update", False):
+            from .helpers.cli_update import print_check_update
+
+            self._pending_exit_code = print_check_update()
+            return None
+
+        if getattr(self.args, "self_update", False):
+            from .helpers.cli_update import run_self_update
+
+            self._pending_exit_code = run_self_update()
+            return None
+
+        from .helpers.cli_update import maybe_emit_update_banner
+
+        maybe_emit_update_banner(silent=bool(self.args.silent))
 
         if self.args.list_models:
             # Setup minimal logging without file creation

--- a/oasis/static/css/dashboard.css
+++ b/oasis/static/css/dashboard.css
@@ -2437,7 +2437,7 @@ body.modal-open {
     }
 }
 .oasis-assistant-log {
-    max-height: 540px;
+    max-height: 640px;
     overflow-y: auto;
     background: var(--light-gray);
     padding: 0.65rem 0.5rem;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     { name = "psyray" }
 ]
 dependencies = [
+    "packaging>=24.0",
     "pydantic>=2.10.0",
     "langchain-core>=0.3.15",
     "langgraph>=0.2.45",

--- a/tests/test_assistant_think_parse.py
+++ b/tests/test_assistant_think_parse.py
@@ -111,6 +111,16 @@ class TestAssistantThinkParse(unittest.TestCase):
         self.assertEqual(split.thought_segments, ["One.", "Two."])
         self.assertEqual(split.visible_markdown, "## Final\n\nText.")
 
+    def test_channel_thought_prefers_earliest_boundary(self):
+        raw = (
+            "<|channel>thought <channel|>reasoning notes.\n\n"
+            "Visible reply starts here."
+            "<|channel>thought <channel|>later block."
+        )
+        split = parse_assistant_think(raw)
+        self.assertEqual(split.thought_segments, ["reasoning notes.", "later block."])
+        self.assertEqual(split.visible_markdown, "Visible reply starts here.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_assistant_think_parse.py
+++ b/tests/test_assistant_think_parse.py
@@ -76,6 +76,41 @@ class TestAssistantThinkParse(unittest.TestCase):
         self.assertEqual(split.thought_segments, ["Only thinking text here."])
         self.assertEqual(split.visible_markdown, "")
 
+    def test_channel_thought_double_word_opener(self):
+        raw = (
+            "<|channel>thought thought <channel|>Dup token opener.\n\n"
+            "## Answer\n\nDone."
+        )
+        split = parse_assistant_think(raw)
+        self.assertEqual(split.thought_segments, ["Dup token opener."])
+        self.assertEqual(split.visible_markdown, "## Answer\n\nDone.")
+
+    def test_channel_thought_symmetric_close_tag(self):
+        raw = "<|channel>thought <|channel|>Symmetric close.\n\n## A\n\nB."
+        split = parse_assistant_think(raw)
+        self.assertEqual(split.thought_segments, ["Symmetric close."])
+        self.assertEqual(split.visible_markdown, "## A\n\nB.")
+
+    def test_channel_thought_two_blocks_back_to_back(self):
+        raw = (
+            "<|channel>thought <channel|>First block."
+            "<|channel>thought <channel|>Second block.\n\n"
+            "## Reply\n\nOK."
+        )
+        split = parse_assistant_think(raw)
+        self.assertEqual(split.thought_segments, ["First block.", "Second block."])
+        self.assertEqual(split.visible_markdown, "## Reply\n\nOK.")
+
+    def test_channel_thought_two_blocks_then_reply(self):
+        raw = (
+            "<|channel>thought <channel|>One.\n\n"
+            "<|channel>thought <channel|>Two.\n\n"
+            "## Final\n\nText."
+        )
+        split = parse_assistant_think(raw)
+        self.assertEqual(split.thought_segments, ["One.", "Two."])
+        self.assertEqual(split.visible_markdown, "## Final\n\nText.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,186 @@
+"""Unit tests for GitHub-based CLI update helpers."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from packaging.version import Version
+
+from oasis.helpers import cli_update
+
+
+class TestVersionFromTag(unittest.TestCase):
+    def test_strips_leading_v(self):
+        self.assertEqual(cli_update.version_from_tag_name("v1.2.3"), Version("1.2.3"))
+
+    def test_invalid_returns_none(self):
+        self.assertIsNone(cli_update.version_from_tag_name("not-a-version"))
+
+
+class TestPickLatestStableRelease(unittest.TestCase):
+    def test_skips_prerelease_and_draft(self):
+        releases = [
+            {
+                "tag_name": "v2.0.0-beta",
+                "published_at": "2025-03-01T00:00:00Z",
+                "draft": False,
+                "prerelease": True,
+            },
+            {
+                "tag_name": "v1.0.0",
+                "published_at": "2025-01-01T00:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            },
+            {
+                "tag_name": "v9.9.9",
+                "published_at": "2026-06-01T00:00:00Z",
+                "draft": True,
+                "prerelease": False,
+            },
+        ]
+        picked = cli_update.pick_latest_stable_release(releases)
+        self.assertIsNotNone(picked)
+        assert picked is not None
+        self.assertEqual(str(picked.version), "1.0.0")
+        self.assertEqual(picked.tag_name, "v1.0.0")
+
+    def test_newest_by_published_at(self):
+        releases = [
+            {
+                "tag_name": "v1.0.0",
+                "published_at": "2025-01-01T00:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            },
+            {
+                "tag_name": "v1.1.0",
+                "published_at": "2025-06-01T00:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            },
+        ]
+        picked = cli_update.pick_latest_stable_release(releases)
+        self.assertIsNotNone(picked)
+        assert picked is not None
+        self.assertEqual(str(picked.version), "1.1.0")
+
+
+class TestPrintCheckUpdate(unittest.TestCase):
+    def test_github_unreachable_returns_one(self):
+        with patch.object(cli_update, "fetch_latest_stable_release", return_value=None):
+            rc = cli_update.print_check_update()
+        self.assertEqual(rc, 1)
+
+    def test_up_to_date_zero(self):
+        fake = cli_update.StableRelease(
+            tag_name="v99.99.99",
+            version=Version("99.99.99"),
+            published_at="2026-01-01T00:00:00Z",
+        )
+        with patch.object(cli_update, "fetch_latest_stable_release", return_value=fake):
+            with patch.object(cli_update, "installed_version_string", return_value="99.99.99"):
+                rc = cli_update.print_check_update()
+        self.assertEqual(rc, 0)
+
+
+class TestRunSelfUpdate(unittest.TestCase):
+    def test_editable_returns_one(self):
+        with patch.object(cli_update, "is_site_packages_install", return_value=False):
+            rc = cli_update.run_self_update()
+        self.assertEqual(rc, 1)
+
+    def test_up_to_date_skips_pipx(self):
+        fake = cli_update.StableRelease(
+            tag_name="v0.0.1",
+            version=Version("0.0.1"),
+            published_at="2020-01-01T00:00:00Z",
+        )
+        with patch.object(cli_update, "is_site_packages_install", return_value=True):
+            with patch.object(cli_update, "fetch_latest_stable_release", return_value=fake):
+                with patch.object(cli_update, "installed_version_string", return_value="1.0.0"):
+                    with patch.object(cli_update.subprocess, "run") as run:
+                        rc = cli_update.run_self_update()
+        run.assert_not_called()
+        self.assertEqual(rc, 0)
+
+    def test_upgrade_invokes_pipx(self):
+        fake = cli_update.StableRelease(
+            tag_name="v2.0.0",
+            version=Version("2.0.0"),
+            published_at="2026-01-01T00:00:00Z",
+        )
+        proc = MagicMock()
+        proc.returncode = 0
+        with patch.object(cli_update, "is_site_packages_install", return_value=True):
+            with patch.object(cli_update, "fetch_latest_stable_release", return_value=fake):
+                with patch.object(cli_update, "installed_version_string", return_value="1.0.0"):
+                    with patch.object(cli_update.shutil, "which", return_value="/usr/bin/pipx"):
+                        with patch.object(cli_update.subprocess, "run", return_value=proc) as run:
+                            rc = cli_update.run_self_update()
+        self.assertEqual(rc, 0)
+        args = run.call_args[0][0]
+        self.assertEqual(
+            args[:4],
+            ["/usr/bin/pipx", "install", "--force", "git+https://github.com/psyray/oasis.git@v2.0.0"],
+        )
+
+
+class TestMaybeEmitBanner(unittest.TestCase):
+    def test_respects_silent(self):
+        with patch.object(cli_update, "resolve_latest_stable_for_notice") as res:
+            cli_update.maybe_emit_update_banner(silent=True)
+        res.assert_not_called()
+
+    def test_respects_env(self):
+        with patch.dict(os.environ, {cli_update.ENV_DISABLE_CHECK: "1"}, clear=False):
+            with patch.object(cli_update, "resolve_latest_stable_for_notice") as res:
+                cli_update.maybe_emit_update_banner(silent=False)
+        res.assert_not_called()
+
+
+class TestCacheRoundTrip(unittest.TestCase):
+    def test_cache_refresh_writes_file(self):
+        fake = cli_update.StableRelease(
+            tag_name="v1.2.3",
+            version=Version("1.2.3"),
+            published_at="2026-02-01T00:00:00Z",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td) / "cache"
+            with patch.dict(os.environ, {"XDG_CACHE_HOME": str(base)}, clear=False):
+                with patch.object(cli_update, "fetch_latest_stable_release", return_value=fake):
+                    rel, net = cli_update.resolve_latest_stable_for_notice(force_refresh=True)
+                self.assertTrue(net)
+                self.assertIsNotNone(rel)
+                path = cli_update.cache_file_path()
+                self.assertTrue(path.is_file())
+                data = json.loads(path.read_text(encoding="utf-8"))
+                self.assertEqual(data["tag_name"], "v1.2.3")
+
+
+class TestOasisCliUpdateFlags(unittest.TestCase):
+    def test_parse_check_and_self_exclusive(self):
+        from oasis.oasis import OasisScanner
+
+        scanner = OasisScanner()
+        parser = scanner.setup_argument_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            parser.parse_args(["--check-update", "--self-update"])
+        self.assertEqual(ctx.exception.code, 2)
+        td = tempfile.mkdtemp()
+        try:
+            ns = parser.parse_args(["-i", td, "--check-update"])
+            self.assertTrue(ns.check_update)
+            self.assertFalse(ns.self_update)
+        finally:
+            Path(td).rmdir()
+

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,11 +1,14 @@
 """Unit tests for GitHub-based CLI update helpers."""
 
+import contextlib
+import io
 import json
 import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -91,6 +94,23 @@ class TestPrintCheckUpdate(unittest.TestCase):
                 rc = cli_update.print_check_update()
         self.assertEqual(rc, 0)
 
+    def test_update_available_prints_message_and_command(self):
+        latest = cli_update.StableRelease(
+            tag_name="v2.0.0",
+            version=Version("2.0.0"),
+            published_at="2026-01-01T00:00:00Z",
+        )
+        with patch.object(cli_update, "fetch_latest_stable_release", return_value=latest):
+            with patch.object(cli_update, "installed_version_string", return_value="1.0.0"):
+                with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                    rc = cli_update.print_check_update()
+
+        output = stdout.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("Update available", output)
+        self.assertIn("oasis --self-update", output)
+        self.assertIn("pipx install", output)
+
 
 class TestRunSelfUpdate(unittest.TestCase):
     def test_editable_returns_one(self):
@@ -133,6 +153,40 @@ class TestRunSelfUpdate(unittest.TestCase):
             ["/usr/bin/pipx", "install", "--force", "git+https://github.com/psyray/oasis.git@v2.0.0"],
         )
 
+    def test_run_self_update_pipx_not_found(self):
+        fake = cli_update.StableRelease(
+            tag_name="v0.0.2",
+            version=Version("0.0.2"),
+            published_at="2020-01-02T00:00:00Z",
+        )
+        stderr = io.StringIO()
+        with patch.object(cli_update, "is_site_packages_install", return_value=True):
+            with patch.object(cli_update, "fetch_latest_stable_release", return_value=fake):
+                with patch.object(cli_update, "installed_version_string", return_value="0.0.1"):
+                    with patch.object(cli_update.shutil, "which", return_value=None):
+                        with contextlib.redirect_stderr(stderr):
+                            rc = cli_update.run_self_update()
+        self.assertEqual(rc, 1)
+        self.assertIn("pipx", stderr.getvalue().lower())
+
+    def test_run_self_update_propagates_non_zero_returncode(self):
+        fake = cli_update.StableRelease(
+            tag_name="v0.0.2",
+            version=Version("0.0.2"),
+            published_at="2020-01-02T00:00:00Z",
+        )
+        completed = SimpleNamespace(returncode=3)
+        with patch.object(cli_update, "is_site_packages_install", return_value=True):
+            with patch.object(cli_update, "fetch_latest_stable_release", return_value=fake):
+                with patch.object(cli_update, "installed_version_string", return_value="0.0.1"):
+                    with patch.object(cli_update.shutil, "which", return_value="/usr/bin/pipx"):
+                        with patch.object(
+                            cli_update.subprocess, "run", return_value=completed
+                        ) as run:
+                            rc = cli_update.run_self_update()
+        run.assert_called_once()
+        self.assertEqual(rc, 3)
+
 
 class TestMaybeEmitBanner(unittest.TestCase):
     def test_respects_silent(self):
@@ -145,6 +199,23 @@ class TestMaybeEmitBanner(unittest.TestCase):
             with patch.object(cli_update, "resolve_latest_stable_for_notice") as res:
                 cli_update.maybe_emit_update_banner(silent=False)
         res.assert_not_called()
+
+    def test_emits_banner_when_update_available(self):
+        latest = cli_update.StableRelease(
+            tag_name="v2.0.0",
+            version=Version("2.0.0"),
+            published_at="2026-01-01T00:00:00Z",
+        )
+        with patch.object(cli_update, "installed_version_string", return_value="1.0.0"):
+            with patch.object(
+                cli_update, "get_latest_stable_release", return_value=(latest, True)
+            ):
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    cli_update.maybe_emit_update_banner(silent=False)
+        output = stderr.getvalue()
+        self.assertIn("oasis: update available", output)
+        self.assertIn("pipx install --force", output)
 
 
 class TestCacheRoundTrip(unittest.TestCase):
@@ -183,4 +254,44 @@ class TestOasisCliUpdateFlags(unittest.TestCase):
             self.assertFalse(ns.self_update)
         finally:
             Path(td).rmdir()
+
+
+class TestOasisCliUpdateFlow(unittest.TestCase):
+    @patch.object(cli_update, "print_check_update", return_value=11)
+    def test_check_update_sets_pending_exit_code_and_skips_scan_init(
+        self, mock_print_check_update
+    ):
+        from oasis.oasis import OasisScanner
+
+        scanner = OasisScanner()
+        ns = scanner.setup_argument_parser().parse_args(["--check-update"])
+        init_result = scanner._init_arguments(ns)
+        self.assertIsNone(init_result)
+        self.assertEqual(scanner._pending_exit_code, 11)
+        mock_print_check_update.assert_called_once()
+
+        with patch.object(scanner, "_init_ollama") as mock_init_ollama:
+            rc = scanner._init_oasis(ns)
+
+        self.assertEqual(rc, 11)
+        mock_init_ollama.assert_not_called()
+
+    @patch.object(cli_update, "run_self_update", return_value=22)
+    def test_self_update_sets_pending_exit_code_and_skips_scan_init(
+        self, mock_run_self_update
+    ):
+        from oasis.oasis import OasisScanner
+
+        scanner = OasisScanner()
+        ns = scanner.setup_argument_parser().parse_args(["--self-update"])
+        init_result = scanner._init_arguments(ns)
+        self.assertIsNone(init_result)
+        self.assertEqual(scanner._pending_exit_code, 22)
+        mock_run_self_update.assert_called_once()
+
+        with patch.object(scanner, "_init_ollama") as mock_init_ollama:
+            rc = scanner._init_oasis(ns)
+
+        self.assertEqual(rc, 22)
+        mock_init_ollama.assert_not_called()
 

--- a/tests/test_oasis_cli.py
+++ b/tests/test_oasis_cli.py
@@ -164,6 +164,8 @@ class TestOasisCliInitArguments(unittest.TestCase):
     def _build_init_namespace(input_path: str, output_format: str = "%%%invalid%%%"):
         namespace = MagicMock()
         namespace.version = False
+        namespace.check_update = False
+        namespace.self_update = False
         namespace.list_models = False
         namespace.silent = False
         namespace.models = None


### PR DESCRIPTION
## Summary
Add GitHub-based CLI update checking and self-update capabilities, along with internal parsing robustness improvements and supporting tests/docs.

## New Features:
- Introduce --check-update and --self-update CLI flags to compare the installed version with the latest stable GitHub release and trigger self-upgrade via pipx.
- Add automatic optional update banner output when a newer stable GitHub release is available.

## Bug Fixes:
- Make assistant reasoning channel parsing more robust to variant opener/closer tags and multiple back-to-back reasoning blocks.

## Enhancements:
- Adjust the dashboard assistant log panel height to show more content without scrolling.

## Build:
- Declare packaging as a runtime dependency for version parsing and comparison in update logic.

## Documentation:
- Document CLI update and self-update usage, environment controls, and release-based update workflow in README and CHANGELOG.

## Tests:
- Add unit tests for CLI update helpers, caching behavior, and new update flags, plus extended coverage for assistant reasoning channel parsing.