### PR TITLE
feat(report): add executive summary rendering to report generation

### DIFF
--- a/oasis/report.py
+++ b/oasis/report.py
@@ -1,5 +1,4 @@
 import base64
-from html import escape
 import json
 import logging
 import math
@@ -350,48 +349,27 @@ class Report:
         return template.render(document=doc.model_dump(mode="json"))
 
     def _render_executive_summary_inner_html(self, payload: Dict[str, Any]) -> str:
-        title = escape(str(payload.get("title") or "Executive Summary"))
-        generated_at = escape(str(payload.get("generated_at") or "N/A"))
-        deep_model = escape(str(payload.get("deep_model") or payload.get("model_name") or "N/A"))
-        small_model = escape(str(payload.get("small_model") or "N/A"))
-        embedding_model = escape(str(payload.get("embedding_model") or "N/A"))
-
-        vuln_summary = payload.get("vulnerability_summary") or {}
-        tier_counts = payload.get("similarity_tier_counts") or {}
-        if not isinstance(vuln_summary, dict):
-            vuln_summary = {}
-        if not isinstance(tier_counts, dict):
-            tier_counts = {}
-
-        vuln_items = "\n".join(
-            f"<li><strong>{escape(str(name))}</strong>: {escape(str(count))}</li>"
-            for name, count in sorted(vuln_summary.items(), key=lambda item: str(item[0]).lower())
-        ) or "<li>No vulnerability summary available.</li>"
-        tier_items = "\n".join(
-            f"<li><strong>{escape(str(tier))}</strong>: {escape(str(count))}</li>"
-            for tier, count in sorted(tier_counts.items(), key=lambda item: str(item[0]).lower())
-        ) or "<li>No similarity tier data available.</li>"
-
-        return f"""
-<article class="report-executive-summary">
-  <h1>{title}</h1>
-  <p><strong>Generated at:</strong> {generated_at}</p>
-  <h2>Models Used</h2>
-  <ul>
-    <li><strong>Deep model:</strong> {deep_model}</li>
-    <li><strong>Small model:</strong> {small_model}</li>
-    <li><strong>Embedding model:</strong> {embedding_model}</li>
-  </ul>
-  <h2>Vulnerability Summary</h2>
-  <ul>
-    {vuln_items}
-  </ul>
-  <h2>Similarity Tier Counts</h2>
-  <ul>
-    {tier_items}
-  </ul>
-</article>
-"""
+        vuln_summary = payload.get("vulnerability_summary")
+        tier_counts = payload.get("similarity_tier_counts")
+        safe_payload = {
+            "title": str(payload.get("title") or "Executive Summary"),
+            "generated_at": str(payload.get("generated_at") or "N/A"),
+            "deep_model": str(payload.get("deep_model") or payload.get("model_name") or "N/A"),
+            "small_model": str(payload.get("small_model") or "N/A"),
+            "embedding_model": str(payload.get("embedding_model") or "N/A"),
+            "vulnerability_summary": (
+                sorted(vuln_summary.items(), key=lambda item: str(item[0]).lower())
+                if isinstance(vuln_summary, dict)
+                else []
+            ),
+            "similarity_tier_counts": (
+                sorted(tier_counts.items(), key=lambda item: str(item[0]).lower())
+                if isinstance(tier_counts, dict)
+                else []
+            ),
+        }
+        template = self.template_env.get_template("reports/executive_summary_from_json.html.j2")
+        return template.render(payload=safe_payload)
 
     def render_report_html_from_json_payload(self, payload: Dict) -> str:
         """
@@ -817,12 +795,13 @@ class Report:
             tier_id: len(similarity_groups.get(tier_id) or [])
             for tier_id, _ in EXEC_SUMMARY_EMBEDDING_TIER_ORDER
         }
-        primary_model = deep_model_name.strip() or str(model_name or "").strip()
+        deep_model = str(deep_model_name or "").strip()
+        primary_model = deep_model or str(model_name or "").strip()
         return {
             "report_type": "executive_summary",
             "schema_version": 1,
             "model_name": primary_model,
-            "deep_model": deep_model_name,
+            "deep_model": deep_model,
             "small_model": scan_model_name,
             "embedding_model": embedding_model_name,
             "title": "Executive Summary",

--- a/oasis/report.py
+++ b/oasis/report.py
@@ -1,4 +1,5 @@
 import base64
+from html import escape
 import json
 import logging
 import math
@@ -348,19 +349,64 @@ class Report:
         template = self.template_env.get_template("reports/vulnerability_export.md.j2")
         return template.render(document=doc.model_dump(mode="json"))
 
+    def _render_executive_summary_inner_html(self, payload: Dict[str, Any]) -> str:
+        title = escape(str(payload.get("title") or "Executive Summary"))
+        generated_at = escape(str(payload.get("generated_at") or "N/A"))
+        deep_model = escape(str(payload.get("deep_model") or payload.get("model_name") or "N/A"))
+        small_model = escape(str(payload.get("small_model") or "N/A"))
+        embedding_model = escape(str(payload.get("embedding_model") or "N/A"))
+
+        vuln_summary = payload.get("vulnerability_summary") or {}
+        tier_counts = payload.get("similarity_tier_counts") or {}
+        if not isinstance(vuln_summary, dict):
+            vuln_summary = {}
+        if not isinstance(tier_counts, dict):
+            tier_counts = {}
+
+        vuln_items = "\n".join(
+            f"<li><strong>{escape(str(name))}</strong>: {escape(str(count))}</li>"
+            for name, count in sorted(vuln_summary.items(), key=lambda item: str(item[0]).lower())
+        ) or "<li>No vulnerability summary available.</li>"
+        tier_items = "\n".join(
+            f"<li><strong>{escape(str(tier))}</strong>: {escape(str(count))}</li>"
+            for tier, count in sorted(tier_counts.items(), key=lambda item: str(item[0]).lower())
+        ) or "<li>No similarity tier data available.</li>"
+
+        return f"""
+<article class="report-executive-summary">
+  <h1>{title}</h1>
+  <p><strong>Generated at:</strong> {generated_at}</p>
+  <h2>Models Used</h2>
+  <ul>
+    <li><strong>Deep model:</strong> {deep_model}</li>
+    <li><strong>Small model:</strong> {small_model}</li>
+    <li><strong>Embedding model:</strong> {embedding_model}</li>
+  </ul>
+  <h2>Vulnerability Summary</h2>
+  <ul>
+    {vuln_items}
+  </ul>
+  <h2>Similarity Tier Counts</h2>
+  <ul>
+    {tier_items}
+  </ul>
+</article>
+"""
+
     def render_report_html_from_json_payload(self, payload: Dict) -> str:
         """
         Render report HTML directly from canonical JSON payload.
         """
         report_type = payload.get("report_type")
-        if report_type != "vulnerability":
-            raise ValueError(f"Unsupported canonical report type: {report_type}")
-
-        doc = VulnerabilityReportDocument.model_validate(payload)
-        # Keep JSON payload and template rendering aligned on one stats helper.
-        doc.stats = self._compute_document_stats(doc.files)
-        inner_html = self._render_vulnerability_inner_html(doc)
-        return self.render_template(inner_html)
+        if report_type == "vulnerability":
+            doc = VulnerabilityReportDocument.model_validate(payload)
+            # Keep JSON payload and template rendering aligned on one stats helper.
+            doc.stats = self._compute_document_stats(doc.files)
+            inner_html = self._render_vulnerability_inner_html(doc)
+            return self.render_template(inner_html)
+        if report_type == "executive_summary":
+            return self.render_template(self._render_executive_summary_inner_html(payload))
+        raise ValueError(f"Unsupported canonical report type: {report_type}")
 
     def generate_vulnerability_report(
         self, vulnerability: Dict, results: List[Dict], model_name: str
@@ -771,7 +817,7 @@ class Report:
             tier_id: len(similarity_groups.get(tier_id) or [])
             for tier_id, _ in EXEC_SUMMARY_EMBEDDING_TIER_ORDER
         }
-        primary_model = deep_model_name.strip() if deep_model_name.strip() else str(model_name or "").strip()
+        primary_model = deep_model_name.strip() or str(model_name or "").strip()
         return {
             "report_type": "executive_summary",
             "schema_version": 1,

--- a/oasis/templates/reports/executive_summary_from_json.html.j2
+++ b/oasis/templates/reports/executive_summary_from_json.html.j2
@@ -1,0 +1,30 @@
+<article class="report-executive-summary">
+  <h1>{{ payload.title }}</h1>
+  <p><strong>Generated at:</strong> {{ payload.generated_at }}</p>
+  <h2>Models Used</h2>
+  <ul>
+    <li><strong>Deep model:</strong> {{ payload.deep_model }}</li>
+    <li><strong>Small model:</strong> {{ payload.small_model }}</li>
+    <li><strong>Embedding model:</strong> {{ payload.embedding_model }}</li>
+  </ul>
+  <h2>Vulnerability Summary</h2>
+  <ul>
+    {% if payload.vulnerability_summary %}
+    {% for name, count in payload.vulnerability_summary %}
+    <li><strong>{{ name }}</strong>: {{ count }}</li>
+    {% endfor %}
+    {% else %}
+    <li>No vulnerability summary available.</li>
+    {% endif %}
+  </ul>
+  <h2>Similarity Tier Counts</h2>
+  <ul>
+    {% if payload.similarity_tier_counts %}
+    {% for tier, count in payload.similarity_tier_counts %}
+    <li><strong>{{ tier }}</strong>: {{ count }}</li>
+    {% endfor %}
+    {% else %}
+    <li>No similarity tier data available.</li>
+    {% endif %}
+  </ul>
+</article>

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -318,6 +318,22 @@ class TestReportSchema(unittest.TestCase):
         self.assertIn("strong", html)
 
     @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_build_executive_summary_json_document_handles_none_deep_model_name(self):
+        report = Report.__new__(Report)
+
+        payload = report._build_executive_summary_json_document(
+            all_results={},
+            model_name="fallback-model",
+            deep_model_name=None,
+            scan_model_name="scan-model",
+            embedding_model_name="embed-model",
+            similarity_groups={},
+        )
+
+        self.assertEqual(payload["model_name"], "fallback-model")
+        self.assertEqual(payload["deep_model"], "")
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
     def test_render_report_html_from_json_payload_rejects_unknown_report_type(self):
         report = Report(input_path=".", output_format=["md"])
         with self.assertRaises(ValueError):

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -295,6 +295,34 @@ class TestReportSchema(unittest.TestCase):
         self.assertEqual(restored.schema_version, doc.schema_version)
         self.assertEqual(restored.stats.files_analyzed, doc.stats.files_analyzed)
 
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_report_html_from_json_payload_supports_executive_summary(self):
+        report = Report(input_path=".", output_format=["md"])
+        payload = {
+            "report_type": "executive_summary",
+            "title": "Executive Summary",
+            "generated_at": "2026-01-01T00:00:00Z",
+            "model_name": "deep-model",
+            "deep_model": "deep-model",
+            "small_model": "scan-model",
+            "embedding_model": "embed-model",
+            "vulnerability_summary": {"SQL Injection": 2, "XSS": 1},
+            "similarity_tier_counts": {"strong": 2, "moderate": 1, "weak": 0},
+        }
+
+        html = report.render_report_html_from_json_payload(payload)
+
+        self.assertIn("Executive Summary", html)
+        self.assertIn("deep-model", html)
+        self.assertIn("SQL Injection", html)
+        self.assertIn("strong", html)
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_report_html_from_json_payload_rejects_unknown_report_type(self):
+        report = Report(input_path=".", output_format=["md"])
+        with self.assertRaises(ValueError):
+            report.render_report_html_from_json_payload({"report_type": "unknown"})
+
     def test_scan_verdict_accepts_error_value(self):
         verdict = ScanVerdict.model_validate({"verdict": "ERROR"})
         self.assertEqual(verdict.verdict, "ERROR")


### PR DESCRIPTION
Add HTML rendering support for executive summary reports alongside existing vulnerability reports and validate handling of unknown report types.

New Features:
- Add HTML rendering for executive summary reports from canonical JSON payloads.
- Support multiple report types (vulnerability and executive_summary) in JSON-driven HTML report generation.

Bug Fixes:
- Ensure primary model selection for executive summaries falls back cleanly when deep model names are blank.
- Raise a clear error when an unknown report type is provided to HTML report rendering.

Tests:
- Add tests covering executive summary HTML rendering and rejection of unknown report types in JSON-driven report generation.