### PR TITLE
feat(web): improve report filtering and executive preview rendering

### DIFF
--- a/.cursor/rules/oasis-lint-gates-python-js.mdc
+++ b/.cursor/rules/oasis-lint-gates-python-js.mdc
@@ -1,0 +1,34 @@
+---
+description: Prevent recurring Python/JS lint regressions with mandatory pre-completion checks
+globs: **/*.{py,js}
+alwaysApply: false
+---
+
+# OASIS Lint Gates (Python + JavaScript)
+
+Apply this checklist before claiming implementation is done.
+
+## Mandatory final checks
+
+- Run `ReadLints` on every edited Python/JS file.
+- If any new diagnostics appear, fix them before final response.
+- Do not stop at “logic is correct”; code must also be lint-clean.
+
+## Python guardrails
+
+- Do not use broad `except Exception` unless explicitly justified.
+- Prefer specific exception tuples and log warnings on safe fallbacks.
+- Normalize untrusted/coerced values with defensive helpers before casting.
+- Keep shaping logic in small helpers (avoid oversized orchestration functions).
+
+## JavaScript guardrails
+
+- Prefer `else if` over nested `if` inside `else`.
+- Remove redundant operations (`slice(0)`, duplicated transforms, dead branches).
+- Normalize dynamic values once (e.g., `trim()`/`String(...)`) and reuse.
+- Keep rendering blocks decomposed into focused helpers to reduce complexity.
+
+## Verification evidence in responses
+
+- Mention which lint checks were executed.
+- Mention whether diagnostics are now zero (for edited files).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## Unreleased
-
 ## 🚀 [0.6.0] - 2026-04-28
 
 ### Breaking changes
@@ -9,14 +7,20 @@
 
 ### ✨ Added
 
+- 📋 **Executive summary canonical JSON (`schema_version` 2)**: **`overview`** (vulnerability-type count, distinct files touched, total embedding comparisons), embedded **`guidance_markdown`** (how to interpret tiers vs severity), **`tier_definitions`**, and capped **`similarity_highlights`** rows for prioritized review; dashboard/HTML preview surfaces **at-a-glance KPIs**, tier legend, **priority match table** with links to per-type reports, and optional **scan progress** summary so the executive report acts as the central security overview for the run.
 - 📊 **Audit canonical JSON**: `audit_report.json` (`report_type: "audit"`) when `json` is in output formats; Pydantic `AuditReportDocument`; Markdown/HTML generated from the same document so the **Audit Metrics Summary** stays compatible with `audit_metrics_from_markdown_content` / dashboard parsing.
 - 🖥️ **Dashboard**: `/api/reports` reads audit metrics from sibling JSON when available (fallback Markdown); report modal uses `/api/report-html` for `json/audit_report.json` when opening `md/audit_report.md` (canonical JSON preview UX).
 - 📁 **Project-aware reports**: optional **project alias** for organization and improved **project-based** report storage and metadata alongside existing project workflow.
 - 📁 **Dashboard**: filter reports by **project** (`/api/reports?project=…`, stats include `projects` counts).
 - ⚠️ **Dashboard / previews**: reports expose **`codebase_accessible`** and **`assistant_context_warning`** when the scanned tree cannot be resolved or read next to **`security_reports`**; warning banners in list chips, HTML preview (vulnerability / executive / audit), and assistant panel.
 
+### 🐛 Fixed
+
+- 🖼️ **Dashboard HTML preview**: Executive Summary **canonical JSON** (`json/_executive_summary.json`) uses the same compact report-modal spine as other previews: **`executive-preview`** wrapper, **table of contents**, section anchors, and **return-to-TOC** links so **Chart.js** severity rollup and styling match the markdown-augmented path.
+
 ### ⚡ Changed
 
+- 📊 **`/api/stats`**: The per-tier sidebar counts are exposed as **`severity_finding_totals`** (finding counts per tier), replacing the former **`severities`** key — same semantics as before the label fix, clearer name. Executive JSON **`similarity_highlights`** rows include optional **`tier_description`** (embedding tier range text) for UI/tooling without another schema bump.
 - 🧭 **Audit wiring**: single **artifact stem** (`audit_report`) and **`md` → `json` sibling** rules shared by indexing (`json_sibling_for_format_artifact`) and the dashboard (`audit-report-paths.js`); audit HTML preview uses **Jinja `audit_decimal`** for scores/thresholds instead of inline format strings.
 - 📎 **Canonical JSON `analysis_root`**: new reports store the scanned project root **relative to the `security_reports/` directory**; legacy **absolute** paths remain supported via resolution heuristics. Helpers live in **`oasis.helpers.analysis_root_path`** (shared by assistant RAG cache root and **`scan_root`** candidate resolution).
 

--- a/oasis/config.py
+++ b/oasis/config.py
@@ -72,6 +72,8 @@ Transport / diagnostics (same file, separate concern):
 
 Static lists (extensions, models, languages, …) follow those sections.
 """
+
+import contextlib
 import copy
 import logging
 import json
@@ -91,13 +93,11 @@ def _log_warning_main_process(msg: str, *args: Any, **kwargs: Any) -> None:
     Pool workers re-import this module; repeating env clamp warnings there duplicates
     console output and interleaves with tqdm on stderr, corrupting the progress line.
     """
-    try:
+    with contextlib.suppress(Exception):
         from multiprocessing import current_process
 
         if current_process().name != "MainProcess":
             return
-    except Exception:
-        pass
     logger.warning(msg, *args, **kwargs)
 
 
@@ -827,8 +827,15 @@ Your configured **scan threshold** (`--threshold`, default 0.5) decides which fi
 - Consider incorporating these checks into your CI/CD pipeline
 - Use the executive summary to communicate **coverage and similarity-based prioritization** to stakeholders (pair it with detail reports for actual severity)
     """,
+    # Short lead displayed above executive metadata in HTML preview/export.
+    'EXECUTIVE_SUMMARY_LEAD': (
+        "Primary scan-wide security overview: coverage across vulnerability types, "
+        "embedding-similarity tiers (retrieval signal), and quick links into per-type "
+        "reports for authoritative severities and findings."
+    ),
+    # Body only (no ``##`` heading): the Markdown report injects "## How to read…" in
+    # ``generate_executive_summary``; the HTML preview uses the Jinja section heading.
     'EXPLAIN_EXECUTIVE_SUMMARY': f"""
-## How to read this executive summary
 The tables below group analyzed files by **embedding similarity** between each vulnerability type and the file (cosine similarity). This ordering reflects **retrieval relevance**, not exploit severity and not the severity labels inside per-vulnerability JSON/HTML reports.
 
 **Tiers**: {_EXEC_SUMMARY_TIERS_INLINE_TEXT}. For authoritative finding counts and severities, open the linked vulnerability-type reports.

--- a/oasis/helpers/dashboard/__init__.py
+++ b/oasis/helpers/dashboard/__init__.py
@@ -32,7 +32,7 @@ from .exec_summary_tiers import (
     executive_summary_tiers_inline_text,
     executive_summary_tiers_markdown_bullets,
 )
-from .report_preview_html import rewrite_report_preview_anchor_hrefs
+from .report_preview_html import rewrite_report_preview_anchor_hrefs, strip_report_header_for_web_preview
 
 # --- Output formats / Socket.IO / phase cell parsing ---------------------------------
 

--- a/oasis/helpers/dashboard/dashboard_links.py
+++ b/oasis/helpers/dashboard/dashboard_links.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from oasis.export.filenames import artifact_filename
 
@@ -23,7 +23,43 @@ def _model_dir_key(name: str | None) -> str:
 _DETAIL_FORMAT_PRIORITY: tuple[str, ...] = ("json", "html", "md", "pdf", "sarif")
 
 
-def preferred_detail_relative_path_and_format(report: "Report", vuln_stem: str) -> Tuple[str, str]:
+def _fallback_detail_relative_path_from_current_report(
+    vuln_stem: str,
+    *,
+    security_root: Optional[Path],
+    current_report_path: Optional[Path],
+) -> Optional[Tuple[str, str]]:
+    """Resolve detail artifact path from the current report run under ``security_reports``."""
+    if not isinstance(security_root, Path) or not isinstance(current_report_path, Path):
+        return None
+    try:
+        resolved_root = security_root.resolve()
+        resolved_current = current_report_path.resolve()
+        rel_current = resolved_current.relative_to(resolved_root)
+    except (OSError, ValueError):
+        return None
+    # Expected layout: .../<model>/<format>/<report_file>
+    if len(rel_current.parts) < 3:
+        return None
+    model_dir = resolved_current.parent.parent
+    for fmt in _DETAIL_FORMAT_PRIORITY:
+        candidate = model_dir / fmt / artifact_filename(vuln_stem, fmt)
+        if candidate.is_file():
+            return candidate.relative_to(resolved_root).as_posix(), fmt
+    fallback = model_dir / "json" / artifact_filename(vuln_stem.strip() or "unknown", "json")
+    try:
+        return fallback.relative_to(resolved_root).as_posix(), "json"
+    except ValueError:
+        return None
+
+
+def preferred_detail_relative_path_and_format(
+    report: "Report",
+    vuln_stem: str,
+    *,
+    security_root: Optional[Path] = None,
+    current_report_path: Optional[Path] = None,
+) -> Tuple[str, str]:
     """
     Return ``(path_under_security_reports, format_key)`` for a vulnerability stem.
 
@@ -32,7 +68,17 @@ def preferred_detail_relative_path_and_format(report: "Report", vuln_stem: str) 
     """
     model_key = _model_dir_key(report.current_model or "")
     dirs = report.report_dirs.get(model_key)
-    base: Path = report.output_base_dir
+    base_raw = getattr(report, "output_base_dir", None)
+    if not isinstance(base_raw, Path):
+        fallback = _fallback_detail_relative_path_from_current_report(
+            vuln_stem,
+            security_root=security_root,
+            current_report_path=current_report_path,
+        )
+        if fallback:
+            return fallback
+        raise ValueError("report.output_base_dir is unavailable")
+    base: Path = base_raw
 
     def rel_str(p: Path) -> str:
         return p.relative_to(base).as_posix()

--- a/oasis/helpers/dashboard/dashboard_links.py
+++ b/oasis/helpers/dashboard/dashboard_links.py
@@ -53,6 +53,32 @@ def _fallback_detail_relative_path_from_current_report(
         return None
 
 
+def _preferred_detail_from_report_dirs(report: "Report", vuln_stem: str) -> Tuple[str, str]:
+    """Resolve preferred detail artifact from ``report.report_dirs``."""
+    model_key = _model_dir_key(report.current_model or "")
+    dirs = report.report_dirs.get(model_key)
+    base: Path = report.output_base_dir
+
+    def rel_str(p: Path) -> str:
+        return p.relative_to(base).as_posix()
+
+    if dirs:
+        for fmt in _DETAIL_FORMAT_PRIORITY:
+            fmt_dir = dirs.get(fmt)
+            if fmt_dir is None:
+                continue
+            candidate = fmt_dir / artifact_filename(vuln_stem, fmt)
+            if candidate.is_file():
+                return rel_str(candidate), fmt
+        if "json" in dirs:
+            candidate = dirs["json"] / artifact_filename(vuln_stem, "json")
+            return rel_str(candidate), "json"
+
+    stem_clean = vuln_stem.strip() or "unknown"
+    fallback = base / model_key / "pdf" / artifact_filename(stem_clean, "pdf")
+    return rel_str(fallback), "pdf"
+
+
 def preferred_detail_relative_path_and_format(
     report: "Report",
     vuln_stem: str,
@@ -66,39 +92,17 @@ def preferred_detail_relative_path_and_format(
     Chooses the first existing artifact directory entry in priority order; if none exist,
     returns the preferred json path so new scans stay consistent once artifacts land.
     """
-    model_key = _model_dir_key(report.current_model or "")
-    dirs = report.report_dirs.get(model_key)
     base_raw = getattr(report, "output_base_dir", None)
-    if not isinstance(base_raw, Path):
-        fallback = _fallback_detail_relative_path_from_current_report(
-            vuln_stem,
-            security_root=security_root,
-            current_report_path=current_report_path,
-        )
-        if fallback:
-            return fallback
-        raise ValueError("report.output_base_dir is unavailable")
-    base: Path = base_raw
-
-    def rel_str(p: Path) -> str:
-        return p.relative_to(base).as_posix()
-
-    if dirs:
-        for fmt in _DETAIL_FORMAT_PRIORITY:
-            fmt_dir = dirs.get(fmt)
-            if fmt_dir is None:
-                continue
-            candidate = fmt_dir / artifact_filename(vuln_stem, fmt)
-            if candidate.is_file():
-                return rel_str(candidate), fmt
-
-        if "json" in dirs:
-            candidate = dirs["json"] / artifact_filename(vuln_stem, "json")
-            return rel_str(candidate), "json"
-
-    stem_clean = vuln_stem.strip() or "unknown"
-    fallback = base / model_key / "pdf" / artifact_filename(stem_clean, "pdf")
-    return rel_str(fallback), "pdf"
+    if isinstance(base_raw, Path):
+        return _preferred_detail_from_report_dirs(report, vuln_stem)
+    fallback = _fallback_detail_relative_path_from_current_report(
+        vuln_stem,
+        security_root=security_root,
+        current_report_path=current_report_path,
+    )
+    if fallback:
+        return fallback
+    raise ValueError("report.output_base_dir is unavailable and fallback could not be derived")
 
 
 def dashboard_reports_href(relative_under_security: str) -> str:

--- a/oasis/helpers/dashboard/report_preview_html.py
+++ b/oasis/helpers/dashboard/report_preview_html.py
@@ -102,3 +102,20 @@ def rewrite_report_preview_anchor_hrefs(html: str, markdown_file: Path, security
             link["href"] = new_href
 
     return str(soup)
+
+
+def strip_report_header_for_web_preview(html: str) -> str:
+    """
+    Remove export-only report header blocks from dashboard preview HTML.
+
+    Dashboard modals already provide context chrome; keeping ``.report-header`` there
+    duplicates titles and metadata that should remain visible only in exported HTML/PDF.
+    """
+    if not (html or "").strip():
+        return html
+    if ".report-header" not in html:
+        return html
+    soup = BeautifulSoup(html, "html.parser")
+    for header in soup.select(".report-header"):
+        header.decompose()
+    return str(soup)

--- a/oasis/helpers/dashboard/severity_filter.py
+++ b/oasis/helpers/dashboard/severity_filter.py
@@ -17,12 +17,12 @@ _STATS_KEYS: Mapping[str, str] = {
 
 def parse_severity_filter_param(raw: str) -> Tuple[str, ...]:
     """Parse comma-separated severity tiers; unknown tokens dropped; order preserved."""
-    if not raw or not str(raw).strip():
+    if not raw or not raw.strip():
         return ()
     allowed = frozenset(DASHBOARD_SEVERITY_TIERS)
     seen: set[str] = set()
     out: list[str] = []
-    for token in str(raw).split(","):
+    for token in raw.split(","):
         t = token.strip().lower()
         if t in allowed and t not in seen:
             seen.add(t)
@@ -51,13 +51,15 @@ def report_passes_dashboard_severity_filter(report: Mapping[str, Any], tiers: Se
     return json_report_matches_any_severity_tier(report, tiers)
 
 
-def merge_severity_histogram_for_report(
-    severities: MutableMapping[str, int], report: Mapping[str, Any]
+def merge_severity_finding_totals_for_report(
+    finding_totals_by_tier: MutableMapping[str, int], report: Mapping[str, Any]
 ) -> None:
     """
-    Increment per-tier report counts for JSON vulnerability files (excludes Executive Summary).
+    Add per-tier **finding** counts from a JSON vulnerability report (excludes Executive Summary).
 
-    A single report may increment multiple tiers.
+    ``finding_totals_by_tier`` accumulates sums of LLM severity counters (``critical_risk``, …),
+    aligned with dashboard ``risk_summary`` and the "Findings by severity" chart — not the number
+    of report files per tier.
     """
     if report.get("format") != "json":
         return
@@ -66,9 +68,9 @@ def merge_severity_histogram_for_report(
     st = report.get("stats") or {}
     for tier in DASHBOARD_SEVERITY_TIERS:
         key = _STATS_KEYS[tier]
-        if int(st.get(key, 0)) > 0:
-            severities[tier] = severities.get(tier, 0) + 1
+        finding_totals_by_tier[tier] = finding_totals_by_tier.get(tier, 0) + int(st.get(key, 0) or 0)
 
 
-def empty_severity_histogram() -> Dict[str, int]:
+def empty_severity_finding_totals() -> Dict[str, int]:
+    """Return zeroed finding totals per canonical severity tier (for ``/api/stats`` aggregation)."""
     return {tier: 0 for tier in DASHBOARD_SEVERITY_TIERS}

--- a/oasis/helpers/executive_summary.py
+++ b/oasis/helpers/executive_summary.py
@@ -59,6 +59,8 @@ _EXECUTIVE_GUIDANCE_HASH_TO_ID: Dict[str, str] = {
     for variant in _EXECUTIVE_GUIDANCE_VARIANTS
 }
 _DEFAULT_EXECUTIVE_GUIDANCE_ID = _EXECUTIVE_GUIDANCE_VARIANTS[0]["id"]
+EXECUTIVE_DEFAULT_GUIDANCE_MARKDOWN = _EXECUTIVE_GUIDANCE_BY_ID[_DEFAULT_EXECUTIVE_GUIDANCE_ID]
+EXECUTIVE_DEFAULT_GUIDANCE_ID = _DEFAULT_EXECUTIVE_GUIDANCE_ID
 
 
 # Similarity score + tier metadata helpers (shared by canonical JSON and HTML enrichment).
@@ -108,11 +110,14 @@ def trusted_guidance_markdown_for_executive_html(payload: Dict[str, Any]) -> str
     Trust policy:
     - require ``guidance_id`` mapped to a known variant,
     - require ``guidance_markdown`` to match that variant text and digest,
+    - treat bundled default guidance as trusted when ``guidance_id`` is missing,
     - fallback to default bundled guidance for unknown/mismatched payloads.
     """
     raw = payload.get("guidance_markdown")
     if isinstance(raw, str) and raw.strip():
         normalized = raw.strip()
+        if normalized == EXECUTIVE_DEFAULT_GUIDANCE_MARKDOWN:
+            return normalized
         guidance_id = str(payload.get("guidance_id") or "").strip()
         trusted = _EXECUTIVE_GUIDANCE_BY_ID.get(guidance_id)
         if trusted is None:
@@ -121,7 +126,7 @@ def trusted_guidance_markdown_for_executive_html(payload: Dict[str, Any]) -> str
                 logger.warning(msg, "unknown", guidance_id)
             else:
                 logger.debug(msg, "missing", None)
-            return _EXECUTIVE_GUIDANCE_BY_ID[_DEFAULT_EXECUTIVE_GUIDANCE_ID]
+            return EXECUTIVE_DEFAULT_GUIDANCE_MARKDOWN
         computed_guidance_id = _guidance_variant_id_from_markdown(normalized)
         expected_digest = hashlib.sha256(trusted.encode("utf-8")).hexdigest()
         digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
@@ -136,7 +141,7 @@ def trusted_guidance_markdown_for_executive_html(payload: Dict[str, Any]) -> str
             expected_digest[:12],
             digest[:12],
         )
-    return _EXECUTIVE_GUIDANCE_BY_ID[_DEFAULT_EXECUTIVE_GUIDANCE_ID]
+    return EXECUTIVE_DEFAULT_GUIDANCE_MARKDOWN
 
 
 def executive_tier_definitions_payload() -> List[Dict[str, str]]:
@@ -247,10 +252,9 @@ def _executive_summary_lead_text() -> str:
     return str(lead).strip() if isinstance(lead, str) else ""
 
 
-def _derive_overview_defaults(
+def _normalize_overview_input(
     payload: Dict[str, Any],
     vulnerability_summary_items: List[Tuple[Any, Any]],
-    highlights_in: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
     overview_raw = payload.get("overview")
     overview_in = dict(overview_raw) if isinstance(overview_raw, dict) else {}
@@ -271,10 +275,17 @@ def _derive_overview_defaults(
             key_name="unique_source_files",
         ),
     }
-    if overview.get("unique_source_files") is None and highlights_in:
+    return overview
+
+
+def _backfill_overview_from_highlights(
+    overview: Dict[str, Any],
+    highlights: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if overview.get("unique_source_files") is None and highlights:
         unique_paths = {
             str(fp)
-            for row in highlights_in
+            for row in highlights
             if isinstance(row, dict) and (fp := row.get("file_path"))
         }
         if unique_paths:
@@ -282,11 +293,27 @@ def _derive_overview_defaults(
     return overview
 
 
-def _normalize_similarity_highlights(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+def build_similarity_rows_for_executive_html(
+    payload: Dict[str, Any],
+    report: Any,
+    *,
+    preview_context: Optional[Dict[str, Any]] = None,
+) -> List[ExecutiveSimilarityHighlightRow]:
     raw = payload.get("similarity_highlights")
     if not isinstance(raw, list):
         return []
-    return [_row_with_resolved_tier_metadata(row) for row in raw if isinstance(row, dict)]
+    rows: List[ExecutiveSimilarityHighlightRow] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        rows.append(
+            enrich_similarity_highlight_row_for_executive_html(
+                _row_with_resolved_tier_metadata(row),
+                report,
+                preview_context=preview_context,
+            )
+        )
+    return rows
 
 
 def _normalize_tier_definitions(payload: Dict[str, Any]) -> List[Dict[str, str]]:
@@ -399,19 +426,15 @@ def build_executive_summary_html_view_model(
     vulnerability_summary_items = _sorted_summary_items(payload.get("vulnerability_summary"))
     similarity_tier_items = _sorted_summary_items(payload.get("similarity_tier_counts"))
     guidance_html = _render_guidance_html(payload)
-    highlights_in = _normalize_similarity_highlights(payload)
-    overview = _derive_overview_defaults(payload, vulnerability_summary_items, highlights_in)
+    similarity_rows = build_similarity_rows_for_executive_html(
+        payload,
+        report,
+        preview_context=preview_context,
+    )
+    overview = _normalize_overview_input(payload, vulnerability_summary_items)
+    overview = _backfill_overview_from_highlights(overview, similarity_rows)
 
     tier_definitions = _normalize_tier_definitions(payload)
-
-    similarity_rows: List[ExecutiveSimilarityHighlightRow] = [
-        enrich_similarity_highlight_row_for_executive_html(
-            row,
-            report,
-            preview_context=preview_context,
-        )
-        for row in highlights_in
-    ]
     progress_summary = _build_progress_summary(payload)
 
     safe_payload: Dict[str, Any] = {

--- a/oasis/helpers/executive_summary.py
+++ b/oasis/helpers/executive_summary.py
@@ -1,0 +1,424 @@
+"""Executive-summary shaping helpers shared by JSON and HTML report rendering."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any, Dict, List, Optional, TypedDict, Tuple
+
+import markdown
+
+from oasis.config import REPORT
+from oasis.helpers.dashboard import (
+    EXEC_SUMMARY_EMBEDDING_TIER_ORDER,
+    EXEC_SUMMARY_EMBEDDING_TIERS,
+    dashboard_reports_href,
+    executive_summary_tier_heading,
+    preferred_detail_relative_path_and_format,
+)
+from oasis.helpers.progress import (
+    scan_progress_status_meta,
+    scan_progress_vulnerability_counts,
+)
+from oasis.tools import logger
+
+
+class ExecutiveSimilarityFindingInput(TypedDict, total=False):
+    """Input finding shape used to build executive similarity highlight rows."""
+
+    vuln_type: str
+    file_path: str
+    score: Any
+
+
+class ExecutiveSimilarityHighlightRow(TypedDict, total=False):
+    """Row shape consumed by executive summary JSON and HTML tables."""
+
+    tier_id: str
+    tier_name: str
+    tier_description: str
+    vuln_type: str
+    file_path: str
+    similarity_score: float
+    detail_href: str
+
+
+class ExecutiveGuidanceVariant(TypedDict):
+    id: str
+    markdown: str
+
+
+_EXECUTIVE_GUIDANCE_VARIANTS: Tuple[ExecutiveGuidanceVariant, ...] = (
+    {"id": "default.v1", "markdown": REPORT["EXPLAIN_EXECUTIVE_SUMMARY"].strip()},
+)
+_EXECUTIVE_GUIDANCE_BY_ID: Dict[str, str] = {
+    variant["id"]: variant["markdown"] for variant in _EXECUTIVE_GUIDANCE_VARIANTS
+}
+_EXECUTIVE_GUIDANCE_HASH_TO_ID: Dict[str, str] = {
+    hashlib.sha256(variant["markdown"].encode("utf-8")).hexdigest(): variant["id"]
+    for variant in _EXECUTIVE_GUIDANCE_VARIANTS
+}
+_DEFAULT_EXECUTIVE_GUIDANCE_ID = _EXECUTIVE_GUIDANCE_VARIANTS[0]["id"]
+
+
+# Similarity score + tier metadata helpers (shared by canonical JSON and HTML enrichment).
+def _safe_similarity_score(
+    raw_score: Any,
+    *,
+    fallback: float = 0.0,
+    vuln_type: str = "",
+    file_path: str = "",
+) -> float:
+    """Convert executive-summary similarity score defensively."""
+    score_ctx = f" vuln_type={vuln_type!r} file_path={file_path!r}" if (vuln_type or file_path) else ""
+    try:
+        parsed = float(raw_score)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Executive summary JSON: non-numeric similarity score encountered; "
+            "falling back to %s. raw_score=%r.%s",
+            fallback,
+            raw_score,
+            score_ctx,
+        )
+        return fallback
+    if not math.isfinite(parsed):
+        logger.warning(
+            "Executive summary JSON: non-finite similarity score encountered; "
+            "falling back to %s. raw_score=%r.%s",
+            fallback,
+            raw_score,
+            score_ctx,
+        )
+        return fallback
+    return parsed
+
+
+def executive_tier_name_and_description_for_id(tier_id: str) -> Tuple[str, str]:
+    """Canonical tier label and tooltip text for ``tier_id``."""
+    tier_obj = next((t for t in EXEC_SUMMARY_EMBEDDING_TIERS if t["id"] == tier_id), None)
+    if tier_obj is None:
+        return tier_id, tier_id
+    return tier_obj["name"], executive_summary_tier_heading(tier_obj)
+
+
+def trusted_guidance_markdown_for_executive_html(payload: Dict[str, Any]) -> str:
+    """Return trusted guidance markdown for executive-summary HTML rendering.
+
+    Trust policy:
+    - require ``guidance_id`` mapped to a known variant,
+    - require ``guidance_markdown`` to match that variant text and digest,
+    - fallback to default bundled guidance for unknown/mismatched payloads.
+    """
+    raw = payload.get("guidance_markdown")
+    if isinstance(raw, str) and raw.strip():
+        normalized = raw.strip()
+        guidance_id = str(payload.get("guidance_id") or "").strip()
+        trusted = _EXECUTIVE_GUIDANCE_BY_ID.get(guidance_id)
+        if trusted is None:
+            msg = "Executive summary HTML: %s guidance_id=%r; using built-in explanation."
+            if guidance_id:
+                logger.warning(msg, "unknown", guidance_id)
+            else:
+                logger.debug(msg, "missing", None)
+            return _EXECUTIVE_GUIDANCE_BY_ID[_DEFAULT_EXECUTIVE_GUIDANCE_ID]
+        computed_guidance_id = _guidance_variant_id_from_markdown(normalized)
+        expected_digest = hashlib.sha256(trusted.encode("utf-8")).hexdigest()
+        digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+        if normalized == trusted and digest == expected_digest:
+            return normalized
+        logger.warning(
+            "Executive summary HTML: guidance content mismatch for guidance_id=%r "
+            "(computed=%r, expected_sha256=%s..., actual_sha256=%s...); "
+            "using built-in explanation.",
+            guidance_id or None,
+            computed_guidance_id,
+            expected_digest[:12],
+            digest[:12],
+        )
+    return _EXECUTIVE_GUIDANCE_BY_ID[_DEFAULT_EXECUTIVE_GUIDANCE_ID]
+
+
+def executive_tier_definitions_payload() -> List[Dict[str, str]]:
+    return [
+        {
+            "id": tier["id"],
+            "name": tier["name"],
+            "description": executive_summary_tier_heading(tier),
+        }
+        for tier in EXEC_SUMMARY_EMBEDDING_TIERS
+    ]
+
+
+def executive_similarity_highlights_rows(
+    similarity_groups: Dict[str, List[ExecutiveSimilarityFindingInput]],
+    *,
+    max_per_tier: int = 25,
+) -> List[ExecutiveSimilarityHighlightRow]:
+    rows: List[ExecutiveSimilarityHighlightRow] = []
+    for tier_id, _ in EXEC_SUMMARY_EMBEDDING_TIER_ORDER:
+        findings = list(similarity_groups.get(tier_id) or [])
+        scored_findings: List[Tuple[ExecutiveSimilarityFindingInput, float]] = []
+        for finding in findings:
+            vuln_type = str(finding.get("vuln_type", ""))
+            file_path = str(finding.get("file_path", ""))
+            safe_score = _safe_similarity_score(
+                finding.get("score", 0.0),
+                vuln_type=vuln_type,
+                file_path=file_path,
+            )
+            scored_findings.append((finding, safe_score))
+        scored_findings.sort(key=lambda pair: pair[1], reverse=True)
+        rows.extend(
+            _row_with_resolved_tier_metadata(
+                {
+                    "tier_id": tier_id,
+                    "vuln_type": str(finding.get("vuln_type", "")),
+                    "file_path": str(finding.get("file_path", "")),
+                    "similarity_score": round(safe_score, 4),
+                }
+            )
+            for finding, safe_score in scored_findings[:max_per_tier]
+        )
+    return rows
+
+
+def enrich_similarity_highlight_row_for_executive_html(
+    row: Dict[str, Any],
+    report: Any,
+) -> ExecutiveSimilarityHighlightRow:
+    """Add tier tooltip and dashboard detail link to one executive highlight row."""
+    merged = _row_with_resolved_tier_metadata(dict(row))
+    stem = _detail_report_stem_from_similarity_row(merged)
+    detail_href = ""
+    if stem:
+        try:
+            rel_path, _fmt = preferred_detail_relative_path_and_format(report, stem)
+            detail_href = dashboard_reports_href(rel_path)
+        except (FileNotFoundError, KeyError, ValueError) as exc:
+            logger.warning(
+                "Executive summary HTML: could not build detail link for vuln_type=%r; %s",
+                merged.get("vuln_type"),
+                exc,
+            )
+            detail_href = ""
+    merged["detail_href"] = detail_href
+    return merged
+
+
+def _row_with_resolved_tier_metadata(row: Dict[str, Any]) -> ExecutiveSimilarityHighlightRow:
+    """Ensure row exposes canonical ``tier_name`` and ``tier_description`` from ``tier_id``."""
+    merged: ExecutiveSimilarityHighlightRow = dict(row)
+    tid = str(merged.get("tier_id") or "").strip()
+    if not tid:
+        return merged
+    tier_name, tier_description = executive_tier_name_and_description_for_id(tid)
+    merged["tier_id"] = tid
+    if not str(merged.get("tier_name") or "").strip():
+        merged["tier_name"] = tier_name
+    if not str(merged.get("tier_description") or "").strip():
+        merged["tier_description"] = tier_description
+    return merged
+
+
+# Guidance and top-level summary normalization helpers.
+def _sorted_summary_items(mapping: Any) -> List[Tuple[Any, Any]]:
+    if not isinstance(mapping, dict):
+        return []
+    return sorted(mapping.items(), key=lambda item: str(item[0]).lower())
+
+
+def _render_guidance_html(payload: Dict[str, Any]) -> str:
+    return markdown.markdown(
+        trusted_guidance_markdown_for_executive_html(payload),
+        extensions=["tables", "fenced_code", "codehilite"],
+    )
+
+
+def _executive_summary_lead_text() -> str:
+    lead = REPORT.get("EXECUTIVE_SUMMARY_LEAD")
+    return str(lead).strip() if isinstance(lead, str) else ""
+
+
+def _derive_overview_defaults(
+    payload: Dict[str, Any],
+    vulnerability_summary_items: List[Tuple[Any, Any]],
+    highlights_in: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    overview_raw = payload.get("overview")
+    overview_in = dict(overview_raw) if isinstance(overview_raw, dict) else {}
+    overview: Dict[str, Any] = {
+        "vulnerability_types_count": _coerce_non_negative_int(
+            overview_in.get("vulnerability_types_count"),
+            fallback=len(vulnerability_summary_items),
+            key_name="vulnerability_types_count",
+        ),
+        "embedding_comparisons_total": _coerce_non_negative_int(
+            overview_in.get("embedding_comparisons_total"),
+            fallback=None,
+            key_name="embedding_comparisons_total",
+            allow_none_fallback=True,
+        ),
+        "unique_source_files": _coerce_optional_non_negative_int(
+            overview_in.get("unique_source_files"),
+            key_name="unique_source_files",
+        ),
+    }
+    if overview.get("unique_source_files") is None and highlights_in:
+        unique_paths = {
+            str(fp)
+            for row in highlights_in
+            if isinstance(row, dict) and (fp := row.get("file_path"))
+        }
+        if unique_paths:
+            overview["unique_source_files"] = len(unique_paths)
+    return overview
+
+
+def _normalize_similarity_highlights(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw = payload.get("similarity_highlights")
+    if not isinstance(raw, list):
+        return []
+    return [_row_with_resolved_tier_metadata(row) for row in raw if isinstance(row, dict)]
+
+
+def _normalize_tier_definitions(payload: Dict[str, Any]) -> List[Dict[str, str]]:
+    raw = payload.get("tier_definitions")
+    if not isinstance(raw, list):
+        return executive_tier_definitions_payload()
+    normalized: List[Dict[str, str]] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        tier_id = str(row.get("id") or "").strip()
+        tier_name = str(row.get("name") or "").strip()
+        tier_desc = str(row.get("description") or "").strip()
+        if not tier_id and not tier_name and not tier_desc:
+            continue
+        if not tier_name and tier_id:
+            tier_name, _default_desc = executive_tier_name_and_description_for_id(tier_id)
+        if not tier_desc and tier_id:
+            _default_name, tier_desc = executive_tier_name_and_description_for_id(tier_id)
+        normalized.append(
+            {
+                "id": tier_id,
+                "name": tier_name,
+                "description": tier_desc,
+            }
+        )
+    return normalized or executive_tier_definitions_payload()
+
+
+def _coerce_non_negative_int(
+    raw: Any,
+    *,
+    fallback: Optional[int],
+    key_name: str,
+    allow_none_fallback: bool = False,
+) -> Optional[int]:
+    if raw is None and allow_none_fallback:
+        return fallback
+    try:
+        val = int(raw)
+        return max(0, val)
+    except (TypeError, ValueError):
+        if raw is not None:
+            logger.warning(
+                "Executive summary HTML: invalid %s=%r; using fallback %s",
+                key_name,
+                raw,
+                fallback,
+            )
+        return fallback
+
+
+def _coerce_optional_non_negative_int(raw: Any, *, key_name: str) -> Optional[int]:
+    if raw is None:
+        return None
+    return _coerce_non_negative_int(raw, fallback=None, key_name=key_name, allow_none_fallback=True)
+
+
+def _guidance_variant_id_from_markdown(markdown_text: str) -> Optional[str]:
+    digest = hashlib.sha256(markdown_text.encode("utf-8")).hexdigest()
+    return _EXECUTIVE_GUIDANCE_HASH_TO_ID.get(digest)
+
+
+def _detail_report_stem_from_similarity_row(row: Dict[str, Any]) -> str:
+    """Resolve detail-report stem from canonical row keys before fallback derivation."""
+    for key in ("vuln_stem", "vuln_slug", "vulnerability_stem", "vulnerability_slug"):
+        raw = row.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().lower()
+    raw_vuln = str(row.get("vuln_type", "")).strip()
+    return raw_vuln.lower().replace(" ", "_")
+
+
+# Progress payload shaping helper.
+def _build_progress_summary(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    prog = payload.get("progress")
+    if not isinstance(prog, dict):
+        return None
+    try:
+        completed, total = scan_progress_vulnerability_counts(prog)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Executive summary HTML: invalid progress counts payload; %s",
+            exc,
+        )
+        return None
+    try:
+        is_partial, _sk, status_label = scan_progress_status_meta(prog)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Executive summary HTML: invalid progress status payload; %s",
+            exc,
+        )
+        return None
+    return {
+        "status_label": status_label,
+        "completed": completed,
+        "total": total,
+        "is_partial": bool(is_partial),
+    }
+
+
+def build_executive_summary_html_view_model(
+    payload: Dict[str, Any],
+    report: Any,
+) -> Dict[str, Any]:
+    """Shape canonical executive-summary JSON plus HTML-only fields for Jinja."""
+    vulnerability_summary_items = _sorted_summary_items(payload.get("vulnerability_summary"))
+    similarity_tier_items = _sorted_summary_items(payload.get("similarity_tier_counts"))
+    guidance_html = _render_guidance_html(payload)
+    highlights_in = _normalize_similarity_highlights(payload)
+    overview = _derive_overview_defaults(payload, vulnerability_summary_items, highlights_in)
+
+    tier_definitions = _normalize_tier_definitions(payload)
+
+    similarity_rows: List[ExecutiveSimilarityHighlightRow] = [
+        enrich_similarity_highlight_row_for_executive_html(row, report)
+        for row in highlights_in
+    ]
+    progress_summary = _build_progress_summary(payload)
+
+    safe_payload: Dict[str, Any] = {
+        "title": str(payload.get("title") or "Executive Summary"),
+        "executive_lead": _executive_summary_lead_text(),
+        "generated_at": str(payload.get("generated_at") or "N/A"),
+        "deep_model": str(payload.get("deep_model") or payload.get("model_name") or "N/A"),
+        "small_model": str(payload.get("small_model") or "N/A"),
+        "embedding_model": str(payload.get("embedding_model") or "N/A"),
+        "vulnerability_summary": vulnerability_summary_items,
+        "similarity_tier_counts": similarity_tier_items,
+        "project": payload.get("project"),
+        "analysis_root": payload.get("analysis_root"),
+        "guidance_html": guidance_html,
+        "overview": overview,
+        "tier_definitions": tier_definitions,
+        "similarity_rows": similarity_rows,
+        "progress_summary": progress_summary,
+    }
+    oasis_raw = payload.get("oasis_version")
+    if oasis_raw not in (None, ""):
+        safe_payload["oasis_version"] = str(oasis_raw).strip()
+    return safe_payload

--- a/oasis/helpers/executive_summary.py
+++ b/oasis/helpers/executive_summary.py
@@ -186,6 +186,8 @@ def executive_similarity_highlights_rows(
 def enrich_similarity_highlight_row_for_executive_html(
     row: Dict[str, Any],
     report: Any,
+    *,
+    preview_context: Optional[Dict[str, Any]] = None,
 ) -> ExecutiveSimilarityHighlightRow:
     """Add tier tooltip and dashboard detail link to one executive highlight row."""
     merged = _row_with_resolved_tier_metadata(dict(row))
@@ -193,7 +195,12 @@ def enrich_similarity_highlight_row_for_executive_html(
     detail_href = ""
     if stem:
         try:
-            rel_path, _fmt = preferred_detail_relative_path_and_format(report, stem)
+            rel_path, _fmt = preferred_detail_relative_path_and_format(
+                report,
+                stem,
+                security_root=(preview_context or {}).get("_security_root"),
+                current_report_path=(preview_context or {}).get("_current_report_path"),
+            )
             detail_href = dashboard_reports_href(rel_path)
         except (FileNotFoundError, KeyError, ValueError) as exc:
             logger.warning(
@@ -385,6 +392,8 @@ def _build_progress_summary(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]
 def build_executive_summary_html_view_model(
     payload: Dict[str, Any],
     report: Any,
+    *,
+    preview_context: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Shape canonical executive-summary JSON plus HTML-only fields for Jinja."""
     vulnerability_summary_items = _sorted_summary_items(payload.get("vulnerability_summary"))
@@ -396,7 +405,11 @@ def build_executive_summary_html_view_model(
     tier_definitions = _normalize_tier_definitions(payload)
 
     similarity_rows: List[ExecutiveSimilarityHighlightRow] = [
-        enrich_similarity_highlight_row_for_executive_html(row, report)
+        enrich_similarity_highlight_row_for_executive_html(
+            row,
+            report,
+            preview_context=preview_context,
+        )
         for row in highlights_in
     ]
     progress_summary = _build_progress_summary(payload)

--- a/oasis/report.py
+++ b/oasis/report.py
@@ -177,7 +177,20 @@ class Report:
 
         # Configure the Jinja2 environment
         template_dir = Path(__file__).parent / 'templates'
-        self.template_env = Environment(loader=FileSystemLoader(searchpath=str(template_dir)))
+        self.template_env = Environment(
+            loader=FileSystemLoader(searchpath=str(template_dir)),
+            autoescape=lambda template_name: bool(
+                template_name
+                and (
+                    template_name.endswith(".html")
+                    or template_name.endswith(".htm")
+                    or template_name.endswith(".xml")
+                    or template_name.endswith(".html.j2")
+                    or template_name.endswith(".htm.j2")
+                    or template_name.endswith(".xml.j2")
+                )
+            ),
+        )
         register_report_template_filters(self.template_env)
 
     def set_progress_notifier(self, notifier) -> None:
@@ -432,7 +445,11 @@ class Report:
         payload: Dict[str, Any],
         preview_context: Optional[Dict[str, Any]] = None,
     ) -> str:
-        safe_payload = build_executive_summary_html_view_model(payload, self)
+        safe_payload = build_executive_summary_html_view_model(
+            payload,
+            self,
+            preview_context=preview_context,
+        )
         template = self.template_env.get_template("reports/executive_summary_from_json.html.j2")
         return template.render(payload=safe_payload, preview=preview_context or {})
 

--- a/oasis/report.py
+++ b/oasis/report.py
@@ -52,6 +52,8 @@ from .helpers.dashboard import (
 )
 from .helpers.executive_summary import (
     build_executive_summary_html_view_model,
+    EXECUTIVE_DEFAULT_GUIDANCE_ID,
+    EXECUTIVE_DEFAULT_GUIDANCE_MARKDOWN,
     executive_similarity_highlights_rows,
     executive_tier_definitions_payload,
 )
@@ -943,7 +945,8 @@ class Report:
                 "embedding_comparisons_total": comparisons_total,
                 "unique_source_files": _executive_unique_source_files_count(all_results),
             },
-            "guidance_markdown": REPORT["EXPLAIN_EXECUTIVE_SUMMARY"].strip(),
+            "guidance_id": EXECUTIVE_DEFAULT_GUIDANCE_ID,
+            "guidance_markdown": EXECUTIVE_DEFAULT_GUIDANCE_MARKDOWN,
             "tier_definitions": executive_tier_definitions_payload(),
             "similarity_highlights": executive_similarity_highlights_rows(similarity_groups),
         }

--- a/oasis/report.py
+++ b/oasis/report.py
@@ -50,6 +50,11 @@ from .helpers.dashboard import (
     executive_summary_similarity_tier_id,
     preferred_detail_relative_path_and_format,
 )
+from .helpers.executive_summary import (
+    build_executive_summary_html_view_model,
+    executive_similarity_highlights_rows,
+    executive_tier_definitions_payload,
+)
 from .helpers.report_jinja_filters import register_report_template_filters
 from .helpers.progress import (
     SCAN_PROGRESS_EXTENDED_KEYS,
@@ -86,6 +91,15 @@ def progress_timestamp_iso() -> str:
         .isoformat(timespec="milliseconds")
         .replace("+00:00", "Z")
     )
+
+
+def _executive_unique_source_files_count(all_results: Dict[str, List[Dict]]) -> int:
+    paths: set[str] = set()
+    for rs in all_results.values():
+        for r in rs:
+            if fp := r.get("file_path"):
+                paths.add(str(fp))
+    return len(paths)
 
 
 def executive_summary_progress_sidecar_path(json_path: Path) -> Path:
@@ -418,27 +432,7 @@ class Report:
         payload: Dict[str, Any],
         preview_context: Optional[Dict[str, Any]] = None,
     ) -> str:
-        vuln_summary = payload.get("vulnerability_summary")
-        tier_counts = payload.get("similarity_tier_counts")
-        safe_payload = {
-            "title": str(payload.get("title") or "Executive Summary"),
-            "generated_at": str(payload.get("generated_at") or "N/A"),
-            "deep_model": str(payload.get("deep_model") or payload.get("model_name") or "N/A"),
-            "small_model": str(payload.get("small_model") or "N/A"),
-            "embedding_model": str(payload.get("embedding_model") or "N/A"),
-            "vulnerability_summary": (
-                sorted(vuln_summary.items(), key=lambda item: str(item[0]).lower())
-                if isinstance(vuln_summary, dict)
-                else []
-            ),
-            "similarity_tier_counts": (
-                sorted(tier_counts.items(), key=lambda item: str(item[0]).lower())
-                if isinstance(tier_counts, dict)
-                else []
-            ),
-            "project": payload.get("project"),
-            "analysis_root": payload.get("analysis_root"),
-        }
+        safe_payload = build_executive_summary_html_view_model(payload, self)
         template = self.template_env.get_template("reports/executive_summary_from_json.html.j2")
         return template.render(payload=safe_payload, preview=preview_context or {})
 
@@ -912,9 +906,10 @@ class Report:
         exec_scan_root = (
             Path(self.input_path).resolve() if getattr(self, "input_path", None) else None
         )
+        comparisons_total = sum(len(rs) for rs in all_results.values())
         return {
             "report_type": "executive_summary",
-            "schema_version": 1,
+            "schema_version": 2,
             "model_name": primary_model,
             "deep_model": deep_model,
             "small_model": scan_model_name,
@@ -926,6 +921,14 @@ class Report:
             "similarity_tier_counts": tier_counts,
             "project": getattr(self, "project", None),
             "analysis_root": self._stored_analysis_root_value(exec_scan_root),
+            "overview": {
+                "vulnerability_types_count": len(all_results),
+                "embedding_comparisons_total": comparisons_total,
+                "unique_source_files": _executive_unique_source_files_count(all_results),
+            },
+            "guidance_markdown": REPORT["EXPLAIN_EXECUTIVE_SUMMARY"].strip(),
+            "tier_definitions": executive_tier_definitions_payload(),
+            "similarity_highlights": executive_similarity_highlights_rows(similarity_groups),
         }
 
     def _persist_executive_summary_canonical_json(
@@ -1020,10 +1023,12 @@ class Report:
         self._last_summary_model_name = str(model_name or "")
 
         report = self.create_header("Executive Summary", model_name)
+        explain_body = REPORT["EXPLAIN_EXECUTIVE_SUMMARY"].strip()
         report.extend([
             "\n## Overview",
             f"\nAnalyzed {len(all_results)} vulnerability types across the codebase.",
-            REPORT['EXPLAIN_EXECUTIVE_SUMMARY'],
+            "\n## How to read this executive summary",
+            f"\n{explain_body}",
         ])
         deep_model_name, scan_model_name, embedding_model_name = self._get_executive_summary_model_names(
             model_name

--- a/oasis/static/css/report_preview.css
+++ b/oasis/static/css/report_preview.css
@@ -283,6 +283,70 @@
     max-height: 240px;
 }
 
+#report-modal-content .html-content-container .report-executive-lead {
+    margin: 0.5rem 0 1rem;
+    max-width: min(100%, 52rem);
+    font-size: 1.02rem;
+    line-height: 1.45;
+    color: var(--dark-blue-2);
+}
+
+#report-modal-content .html-content-container .report-executive-meta-inline {
+    font-weight: normal;
+}
+
+#report-modal-content .html-content-container .report-executive-section h2 {
+    margin-top: 1.25rem;
+}
+
+#report-modal-content .html-content-container .report-executive-kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 0.75rem 1rem;
+    margin: 0.5rem 0 0;
+}
+
+#report-modal-content .html-content-container .report-executive-kpi {
+    padding: 0.65rem 0.85rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--white);
+}
+
+#report-modal-content .html-content-container .report-executive-kpi dt {
+    margin: 0;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--muted-text, #5c6570);
+}
+
+#report-modal-content .html-content-container .report-executive-kpi dd {
+    margin: 0.35rem 0 0;
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--dark-blue);
+}
+
+#report-modal-content .html-content-container .report-executive-guidance-body {
+    margin-top: 0.5rem;
+}
+
+#report-modal-content .html-content-container .report-executive-guidance-body h2 {
+    font-size: 1.05rem;
+    margin-top: 0.75rem;
+}
+
+#report-modal-content .html-content-container .report-executive-note {
+    margin: 0.35rem 0 0.75rem;
+    font-size: 0.92rem;
+    color: var(--dark-blue-2);
+}
+
+#report-modal-content .html-content-container .report-executive-partial {
+    color: var(--warning-color, #b45309);
+    font-weight: 600;
+}
+
 /* Footer from report_template.html is moved after the assistant panel in JS; normalize print-oriented rules. */
 #report-modal-content > footer.report-footer {
     position: static;

--- a/oasis/static/css/report_preview.css
+++ b/oasis/static/css/report_preview.css
@@ -34,6 +34,24 @@
     font-size: 0.85rem;
     word-break: break-all;
 }
+
+#report-modal-content .html-content-container .report-filter-guard {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin: 0 0 1rem;
+    padding: 0.55rem 0.7rem;
+    border: 1px solid #8bd0dc;
+    border-radius: 6px;
+    background: #f0fbfd;
+    color: var(--dark-blue-2);
+    font-size: 0.88rem;
+}
+
+#report-modal-content .html-content-container .report-filter-guard__icon {
+    font-size: 1rem;
+    line-height: 1;
+}
 #report-modal-content .html-content-container .report-toc,
 #report-modal-content .html-content-container .report-stats-chart {
     box-sizing: border-box;
@@ -197,6 +215,41 @@
     font-weight: 600;
     color: var(--dark-blue-2);
     list-style: none;
+}
+
+#report-modal-content .html-content-container .report-finding-summary .severity {
+    margin-left: 0.4rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+#report-modal-content .html-content-container .report-severity-pill {
+    width: 0.58rem;
+    height: 0.58rem;
+    border-radius: 999px;
+    display: inline-block;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+#report-modal-content .html-content-container .report-severity-pill--critical {
+    background: #8b5cf6;
+}
+
+#report-modal-content .html-content-container .report-severity-pill--high {
+    background: #ef4444;
+}
+
+#report-modal-content .html-content-container .report-severity-pill--medium {
+    background: #f59e0b;
+}
+
+#report-modal-content .html-content-container .report-severity-pill--low {
+    background: #22c55e;
+}
+
+#report-modal-content .html-content-container .report-severity-pill--unknown {
+    background: #64748b;
 }
 
 #report-modal-content .html-content-container .report-finding-summary::-webkit-details-marker {

--- a/oasis/static/js/dashboard/api.js
+++ b/oasis/static/js/dashboard/api.js
@@ -58,6 +58,37 @@ DashboardApp.buildFilterParams = function(options = {}) {
     return params;
 };
 
+/**
+ * Return URL with active dashboard filters appended as query parameters.
+ *
+ * ``baseUrl`` can be either a relative URL or absolute path.
+ */
+DashboardApp.urlWithActiveFilters = function(baseUrl, options = {}) {
+    const rawUrl = String(baseUrl || '').trim();
+    if (!rawUrl) {
+        return rawUrl;
+    }
+    const params = DashboardApp.buildFilterParams(options);
+    if (!params.toString()) {
+        return rawUrl;
+    }
+    const hashIndex = rawUrl.indexOf('#');
+    const urlWithoutHash = hashIndex >= 0 ? rawUrl.slice(0, hashIndex) : rawUrl;
+    const hashFragment = hashIndex >= 0 ? rawUrl.slice(hashIndex) : '';
+
+    const queryIndex = urlWithoutHash.indexOf('?');
+    const pathPart = queryIndex >= 0 ? urlWithoutHash.slice(0, queryIndex) : urlWithoutHash;
+    const existingQuery = queryIndex >= 0 ? urlWithoutHash.slice(queryIndex + 1) : '';
+
+    const mergedParams = new URLSearchParams(existingQuery);
+    params.forEach((value, key) => {
+        mergedParams.append(key, value);
+    });
+
+    const mergedQuery = mergedParams.toString();
+    return `${pathPart}${mergedQuery ? `?${mergedQuery}` : ''}${hashFragment}`;
+};
+
 DashboardApp.fetchReports = function() {
     DashboardApp.debug("Fetching reports...");
     DashboardApp.showLoading('reports-container');
@@ -550,7 +581,8 @@ DashboardApp.fetchExecutivePreviewMeta = function (reportPath) {
     if (!rel) {
         return Promise.reject(new Error('missing report path'));
     }
-    const url = `/api/executive-preview-meta?path=${encodeURIComponent(rel)}`;
+    const baseUrl = `/api/executive-preview-meta?path=${encodeURIComponent(rel)}`;
+    const url = DashboardApp.urlWithActiveFilters(baseUrl);
     return fetch(url, { credentials: 'same-origin', headers: { Accept: 'application/json' } }).then(
         async function (response) {
             const data = await response.json().catch(function () {
@@ -727,7 +759,8 @@ DashboardApp.fetchReportJsonPayload = function (reportPath) {
     if (!rel) {
         return Promise.reject(new Error('missing report path'));
     }
-    const url = `/api/report-json/${encodeURIComponent(rel)}`;
+    const baseUrl = `/api/report-json/${encodeURIComponent(rel)}`;
+    const url = DashboardApp.urlWithActiveFilters(baseUrl);
     return fetch(url, { credentials: 'same-origin' }).then(async function (response) {
         const data = await response.json().catch(() => ({}));
         if (!response.ok) {

--- a/oasis/static/js/dashboard/assistant.js
+++ b/oasis/static/js/dashboard/assistant.js
@@ -306,10 +306,11 @@ DashboardApp.renderAssistantVerdictPanel = function (container, result, txt) {
         container.appendChild(gauge);
     }
 
-    if (result.summary) {
+    const summaryText = typeof result.summary === 'string' ? result.summary.trim() : '';
+    if (summaryText) {
         const narrative = document.createElement('p');
         narrative.className = 'oasis-assistant-validate-narrative';
-        narrative.textContent = result.summary;
+        narrative.textContent = summaryText;
         container.appendChild(narrative);
     }
 
@@ -317,6 +318,8 @@ DashboardApp.renderAssistantVerdictPanel = function (container, result, txt) {
         result.narrative_markdown && String(result.narrative_markdown).trim()
             ? String(result.narrative_markdown).trim()
             : '';
+    const synthesisModelText =
+        typeof result.synthesis_model === 'string' ? String(result.synthesis_model).trim() : '';
     if (llmMd) {
         const llmHead = document.createElement('div');
         llmHead.className = 'oasis-assistant-validate-llm-head';
@@ -324,10 +327,10 @@ DashboardApp.renderAssistantVerdictPanel = function (container, result, txt) {
         llmTitle.className = 'oasis-assistant-validate-llm-title';
         llmTitle.textContent = label('validateLlmNarrativeTitle', 'LLM narrative');
         llmHead.appendChild(llmTitle);
-        if (result.synthesis_model) {
+        if (synthesisModelText) {
             const llmModel = document.createElement('span');
             llmModel.className = 'oasis-assistant-validate-llm-model';
-            llmModel.textContent = String(result.synthesis_model);
+            llmModel.textContent = synthesisModelText;
             llmHead.appendChild(llmModel);
         }
         container.appendChild(llmHead);
@@ -760,14 +763,16 @@ DashboardApp.matchChatModelToOptions = function (reportModel, optionValues) {
     const seed = String(reportModel).trim();
     const opts = Array.isArray(optionValues) ? optionValues.map(String) : [];
     const lower = seed.toLowerCase();
-    const fam = seed.indexOf(':') >= 0 ? seed.slice(0, seed.indexOf(':')).trim() : seed;
+    const seedParts = seed.split(':');
+    const fam = seedParts.length > 1 ? seedParts[0].trim() : seed;
     const famLower = fam.toLowerCase();
 
     const optsLower = opts.map(function (s) {
         return s.toLowerCase();
     });
     const optFamPrefix = opts.map(function (s) {
-        return s.indexOf(':') >= 0 ? s.slice(0, s.indexOf(':')).trim() : s;
+        const parts = s.split(':');
+        return parts.length > 1 ? parts[0].trim() : s;
     });
     const optFamPrefixLower = optFamPrefix.map(function (p) {
         return p.toLowerCase();

--- a/oasis/static/js/dashboard/executive-preview.js
+++ b/oasis/static/js/dashboard/executive-preview.js
@@ -45,8 +45,8 @@ DashboardApp.setupExecutivePreviewCharts = function (reportPath) {
     canvas.setAttribute('aria-label', 'Severity distribution');
     wrap.appendChild(canvas);
     const nav = root.querySelector('.executive-preview-toc, nav.report-toc');
-    if (nav && nav.parentNode === root) {
-        root.insertBefore(wrap, nav.nextSibling);
+    if (nav && nav.parentNode) {
+        nav.parentNode.insertBefore(wrap, nav.nextSibling);
     } else {
         root.insertBefore(wrap, root.firstChild);
     }

--- a/oasis/static/js/dashboard/filters.js
+++ b/oasis/static/js/dashboard/filters.js
@@ -229,10 +229,10 @@ DashboardApp.populateFilters = function() {
         vulnFiltersContainer.innerHTML = vulnFiltersHtml || '<div class="no-data">No vulnerability type available</div>';
     }
 
-    // Populate severity filters (canonical tiers; counts from JSON vuln reports)
+    // Populate severity filters (canonical tiers; counts = finding totals per tier, same as stats.risk_summary)
     const severityFiltersContainer = document.getElementById('severity-filters');
     let severityFiltersHtml = '';
-    const severitiesStats = DashboardApp.stats.severities || {};
+    const severitiesStats = DashboardApp.stats.severity_finding_totals || {};
     const availableSeveritySet = new Set(DashboardApp.SEVERITY_FILTER_ORDER);
     const currentSeverityFilters = DashboardApp.normalizeFilterList(DashboardApp.activeFilters.severities);
     const reconciledSeverityFilters = currentSeverityFilters.filter((t) => availableSeveritySet.has(t));
@@ -523,7 +523,7 @@ DashboardApp.updateFilterCounts = function() {
         }
     });
 
-    const severitiesStats = DashboardApp.stats.severities || {};
+    const severitiesStats = DashboardApp.stats.severity_finding_totals || {};
     const severityFilters = document.querySelectorAll('.filter-option[data-type="severity"]');
     severityFilters.forEach(option => {
         const tier = option.dataset.value;

--- a/oasis/static/js/dashboard/interactions.js
+++ b/oasis/static/js/dashboard/interactions.js
@@ -294,7 +294,9 @@ DashboardApp.updateDatesForModels = function(card, modelNames, vulnType) {
     }
 
     // Fallback API path kept for robustness when local reportData is stale.
-    const params = new URLSearchParams();
+    const params = DashboardApp.buildFilterParams({ includeVulnerability: false });
+    params.delete('model');
+    params.delete('vulnerability');
     if (hasModelFilter) {
         normalizedModels.forEach((modelName) => {
             params.append('model', modelName);
@@ -366,9 +368,9 @@ DashboardApp.updateDatesForVulnerability = function(vulnElement, vulnType) {
         DashboardApp._appendLoadingSpinner(datesContainer);
     }
     
-    const params = new URLSearchParams();
+    const params = DashboardApp.buildFilterParams({ includeVulnerability: false });
+    params.delete('vulnerability');
     params.append('vulnerability', vulnType);
-    DashboardApp.appendActiveSeverityToSearchParams(params);
     fetch(`/api/dates?${params.toString()}`)
         .then(response => {
             if (!response.ok) {

--- a/oasis/static/js/dashboard/modal.js
+++ b/oasis/static/js/dashboard/modal.js
@@ -335,8 +335,15 @@ DashboardApp.openReport = function(path, format, options) {
 
     DashboardApp._resetReportModalScrollPositionsUnlessRestoring(opts);
 
+    const withActiveFilters = function(baseUrl) {
+        if (typeof DashboardApp.urlWithActiveFilters === 'function') {
+            return DashboardApp.urlWithActiveFilters(baseUrl);
+        }
+        return baseUrl;
+    };
+
     const loadMarkdownReportIntoModal = function() {
-        fetch(`/api/report-content/${encodeURIComponent(path)}`)
+        fetch(withActiveFilters(`/api/report-content/${encodeURIComponent(path)}`))
             .then(async (response) => {
                 const data = await response.json();
                 if (!response.ok) {
@@ -373,7 +380,7 @@ DashboardApp.openReport = function(path, format, options) {
             ? DashboardApp.auditReportJsonSiblingPath(path)
             : null;
     if (auditJsonPreviewPath) {
-        fetch(`/api/report-html?path=${encodeURIComponent(auditJsonPreviewPath)}`)
+        fetch(withActiveFilters(`/api/report-html?path=${encodeURIComponent(auditJsonPreviewPath)}`))
             .then(async (response) => {
                 const data = await response.json();
                 if (!response.ok) {
@@ -402,7 +409,7 @@ DashboardApp.openReport = function(path, format, options) {
             .replace('/json/', '/md/')
             .replace(/\.json$/i, '.md');
 
-        fetch(`/api/report-html?path=${encodeURIComponent(path)}`)
+        fetch(withActiveFilters(`/api/report-html?path=${encodeURIComponent(path)}`))
             .then(async (response) => {
                 const data = await response.json();
                 if (!response.ok) {
@@ -426,7 +433,11 @@ DashboardApp.openReport = function(path, format, options) {
             .catch((error) => {
                 console.error('Error fetching canonical HTML preview for JSON path:', error);
                 // Legacy fallback: render markdown companion when canonical JSON HTML preview fails.
-                fetch(`/api/report-content/${encodeURIComponent(markdownPath)}?allow_canonical_json_preview=1`)
+                fetch(
+                    withActiveFilters(
+                        `/api/report-content/${encodeURIComponent(markdownPath)}?allow_canonical_json_preview=1`
+                    )
+                )
                     .then(async (response) => {
                         const data = await response.json();
                         if (!response.ok) {

--- a/oasis/static/js/dashboard/modal.js
+++ b/oasis/static/js/dashboard/modal.js
@@ -52,7 +52,7 @@ DashboardApp._relativePathUnderReportsHref = function(href) {
         if (!u.pathname.startsWith(prefix)) {
             return null;
         }
-        return decodeURIComponent(u.pathname.slice(prefix.length));
+        return decodeURIComponent(u.pathname.substring(prefix.length));
     } catch (e) {
         return null;
     }
@@ -327,7 +327,7 @@ DashboardApp.openReport = function(path, format, options) {
         // Determine vulnerability type from filename
         const vulnType = fileNameWithoutExt.replace(/_/g, ' ')
             .split(' ')
-            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .map(word => word.charAt(0).toUpperCase() + word.substring(1))
             .join(' ');
         
         modalTitle.textContent = vulnType;

--- a/oasis/static/js/dashboard/utils.js
+++ b/oasis/static/js/dashboard/utils.js
@@ -258,7 +258,7 @@ if (typeof DashboardApp !== 'undefined') {
             date,
             format,
             date_visible: date_visible !== undefined ? date_visible : true,
-            stats: stats || { high_risk: 0, medium_risk: 0, low_risk: 0, total_findings: 0, files_analyzed: 0 },
+            stats: stats || { critical_risk: 0, high_risk: 0, medium_risk: 0, low_risk: 0, total_findings: 0, files_analyzed: 0 },
             language,
             alternative_formats: alternative_formats || {},
             timestamp_dir: timestamp_dir || "",

--- a/oasis/static/js/dashboard/views.js
+++ b/oasis/static/js/dashboard/views.js
@@ -246,6 +246,7 @@ DashboardApp.renderListViewWithTemplate = function() {
             (sum, r) => sum + (r.stats?.total_findings ?? r.stats?.total ?? 0),
             0
         );
+        const criticalRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.critical_risk || 0), 0);
         const highRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.high_risk || 0), 0);
         const mediumRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.medium_risk || 0), 0);
         const lowRisk = reportsForVuln.reduce((sum, r) => sum + (r.stats?.low_risk || 0), 0);
@@ -320,6 +321,7 @@ DashboardApp.renderListViewWithTemplate = function() {
             .replace('${modelsHTML}', modelsHTML)
             .replace('${datesHTML}', datesHTML)
             .replace('${totalFindings}', totalFindings)
+            .replace('${criticalRisk}', criticalRisk)
             .replace('${highRisk}', highRisk)
             .replace('${mediumRisk}', mediumRisk)
             .replace('${lowRisk}', lowRisk)

--- a/oasis/static/templates/dashboard_card.html
+++ b/oasis/static/templates/dashboard_card.html
@@ -22,6 +22,10 @@
                 <span class="stat-value">${totalFindings}</span>
                 <span class="stat-label">🔍 Total</span>
             </div>
+            <div class="stat critical-risk">
+                <span class="stat-value">${criticalRisk}</span>
+                <span class="stat-label">🔴 Critical</span>
+            </div>
             <div class="stat high-risk">
                 <span class="stat-value">${highRisk}</span>
                 <span class="stat-label">🚨 High</span>

--- a/oasis/templates/reports/_macros.html.j2
+++ b/oasis/templates/reports/_macros.html.j2
@@ -144,3 +144,94 @@
 </div>
 </details>
 {%- endmacro %}
+
+{# Executive summary (reports/executive_summary_from_json.html.j2) — reusable blocks for parity with other report views #}
+
+{% macro render_executive_guidance_html(guidance_html) -%}
+<section id="exec-guidance" class="report-executive-section report-executive-guidance" aria-labelledby="exec-guidance-heading">
+  <h2 id="exec-guidance-heading">How to read this executive summary</h2>
+  <div class="report-executive-guidance-body">{{ guidance_html | safe }}</div>
+  {{ render_return_to_toc() }}
+</section>
+{%- endmacro %}
+
+{% macro render_executive_kpi_grid(overview) -%}
+<section id="exec-situation" class="report-executive-section" aria-labelledby="exec-situation-heading">
+  <h2 id="exec-situation-heading">Security posture at a glance</h2>
+  <dl class="report-executive-kpi-grid">
+    <div class="report-executive-kpi">
+      <dt>Vulnerability types analyzed</dt>
+      <dd>{{ overview.vulnerability_types_count | default(0, true) }}</dd>
+    </div>
+    <div class="report-executive-kpi">
+      <dt>Distinct source files (embedded scan)</dt>
+      <dd>{% if overview.unique_source_files is defined and overview.unique_source_files is not none %}{{ overview.unique_source_files }}{% else %}—{% endif %}</dd>
+    </div>
+    <div class="report-executive-kpi">
+      <dt>Embedding comparisons (file × type)</dt>
+      <dd>{% if overview.embedding_comparisons_total is defined and overview.embedding_comparisons_total is not none %}{{ overview.embedding_comparisons_total }}{% else %}—{% endif %}</dd>
+    </div>
+  </dl>
+  {{ render_return_to_toc() }}
+</section>
+{%- endmacro %}
+
+{% macro render_executive_tier_definitions_table(tier_definitions) -%}
+<section id="exec-tier-defs" class="report-executive-section" aria-labelledby="exec-tier-defs-heading">
+  <h2 id="exec-tier-defs-heading">Embedding similarity tiers</h2>
+  <p class="report-executive-note">Tiers describe cosine similarity between vulnerability prototypes and source chunks — a <strong>retrieval</strong> signal. They are not CVE severity; always open the vulnerability-type report for structured findings.</p>
+  {% if tier_definitions %}
+  <table class="summary-table">
+    <thead><tr><th>Tier</th><th>Definition</th></tr></thead>
+    <tbody>
+      {% for t in tier_definitions %}
+      <tr><td><strong>{{ t.name | e }}</strong> (<code>{{ t.id | e }}</code>)</td><td>{{ t.description | e }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="report-executive-note">No embedding similarity tiers are defined for this report.</p>
+  {% endif %}
+  {{ render_return_to_toc() }}
+</section>
+{%- endmacro %}
+
+{% macro render_executive_similarity_highlights_table(similarity_rows) -%}
+<section id="exec-highlights" class="report-executive-section" aria-labelledby="exec-highlights-heading">
+  <h2 id="exec-highlights-heading">Priority embedding matches</h2>
+  <p class="report-executive-note">Highest-similarity rows per tier (caps apply). Use <strong>Detail report</strong> for full analysis, severities, and remediation.</p>
+  {% if similarity_rows %}
+  <table class="summary-table">
+    <thead>
+      <tr><th>Tier</th><th>Vulnerability type</th><th>File</th><th>Similarity</th><th>Detail report</th></tr>
+    </thead>
+    <tbody>
+      {% for row in similarity_rows %}
+      <tr>
+        <td><span {% if row.tier_description %}title="{{ row.tier_description | e }}"{% endif %}>{{ row.tier_name | e }}</span></td>
+        <td>{{ row.vuln_type | e }}</td>
+        <td><code>{{ row.file_path | e }}</code></td>
+        <td>{{ "%.4f"|format(row.similarity_score|float) }}</td>
+        <td>{% if row.detail_href %}<a href="{{ row.detail_href | e }}">Open report</a>{% else %}—{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No embedding highlights recorded for this summary.</p>
+  {% endif %}
+  {{ render_return_to_toc() }}
+</section>
+{%- endmacro %}
+
+{% macro render_executive_scan_status(progress_summary) -%}
+<section id="exec-scan-status" class="report-executive-section" aria-labelledby="exec-scan-status-heading">
+  <h2 id="exec-scan-status-heading">Scan status</h2>
+  <p>
+    <strong>{{ progress_summary.status_label | e }}</strong>
+    — vulnerabilities completed: {{ progress_summary.completed }}/{{ progress_summary.total }}
+    {% if progress_summary.is_partial %}<span class="report-executive-partial">(partial run)</span>{% endif %}
+  </p>
+  {{ render_return_to_toc() }}
+</section>
+{%- endmacro %}

--- a/oasis/templates/reports/_macros.html.j2
+++ b/oasis/templates/reports/_macros.html.j2
@@ -11,8 +11,22 @@
 {% endif %}
 {%- endmacro %}
 
+{% macro render_active_filter_guard(preview) -%}
+{% if preview and preview.get('active_severity_filter') %}
+<div class="report-filter-guard" role="status" aria-live="polite">
+  <span class="report-filter-guard__icon" aria-hidden="true">🎯</span>
+  <span class="report-filter-guard__text">
+    Active severity filter:
+    <strong>{{ preview.get('active_severity_filter') | join(', ') }}</strong>
+    — findings shown below are filtered accordingly.
+  </span>
+</div>
+{% endif %}
+{%- endmacro %}
+
 {% macro render_header(document, preview=None) -%}
 {{ render_codebase_warning_banner(preview) }}
+{{ render_active_filter_guard(preview) }}
 <h1>{{ document.title }}</h1>
 <p><strong>Date:</strong> {{ document.generated_at }} &mdash; <strong>Model:</strong> {{ document.model_name }}</p>
 <p><strong>Vulnerability:</strong> {{ document.vulnerability_name }}</p>
@@ -100,46 +114,54 @@
 
 {% macro render_chunk_notes(chunk, file_index, chunk_index) -%}
 <h4>Chunk {{ file_index }}.{{ chunk_index }} notes</h4>
-<pre>{{ chunk.notes }}</pre>
+<pre>{{ chunk.notes | e }}</pre>
 {%- endmacro %}
 
 {% macro render_finding(finding, file_index, finding_index) -%}
 <details class="report-finding-details">
-<summary class="report-finding-summary">Finding {{ file_index }}.{{ finding_index }}: {{ finding.title }} <span class="severity">({{ finding.severity }})</span></summary>
+{% set sev_raw = (finding.severity | default('unknown', true) | string | lower) %}
+{% set sev = sev_raw if sev_raw in ['critical', 'high', 'medium', 'low'] else 'unknown' %}
+<summary class="report-finding-summary">
+  Finding {{ file_index }}.{{ finding_index }}: {{ finding.title | e }}
+  <span class="severity">
+    <span class="report-severity-pill report-severity-pill--{{ sev }}" aria-hidden="true"></span>
+    ({{ finding.severity | e }})
+  </span>
+</summary>
 <div class="report-finding-body">
 {% if finding.vulnerable_code %}
 <h5>Vulnerable code</h5>
-<pre><code>{{ finding.vulnerable_code }}</code></pre>
+<pre><code>{{ finding.vulnerable_code | e }}</code></pre>
 {% endif %}
 <h5>Explanation</h5>
-<p>{{ finding.explanation }}</p>
-{% if finding.impact %}<h5>Impact</h5><p>{{ finding.impact }}</p>{% endif %}
-{% if finding.entry_point %}<h5>Entry point</h5><p>{{ finding.entry_point }}</p>{% endif %}
+<p>{{ finding.explanation | e }}</p>
+{% if finding.impact %}<h5>Impact</h5><p>{{ finding.impact | e }}</p>{% endif %}
+{% if finding.entry_point %}<h5>Entry point</h5><p>{{ finding.entry_point | e }}</p>{% endif %}
 {% if finding.execution_path_diagram %}
 <h5>Execution path</h5>
-<pre><code>{{ finding.execution_path_diagram }}</code></pre>
+<pre><code>{{ finding.execution_path_diagram | e }}</code></pre>
 {% endif %}
-{% if finding.http_methods %}<h5>HTTP methods</h5><p>{{ finding.http_methods | join(', ') }}</p>{% endif %}
-{% if finding.manipulable_parameters %}<h5>Parameters</h5><p>{{ finding.manipulable_parameters | join(', ') }}</p>{% endif %}
+{% if finding.http_methods %}<h5>HTTP methods</h5><p>{{ finding.http_methods | map('e') | join(', ') }}</p>{% endif %}
+{% if finding.manipulable_parameters %}<h5>Parameters</h5><p>{{ finding.manipulable_parameters | map('e') | join(', ') }}</p>{% endif %}
 {% if finding.exploitation_steps %}
 <h5>Exploitation steps</h5>
-<ul>{% for step in finding.exploitation_steps %}<li>{{ step }}</li>{% endfor %}</ul>
+<ul>{% for step in finding.exploitation_steps %}<li>{{ step | e }}</li>{% endfor %}</ul>
 {% endif %}
 {% if finding.example_payloads %}
 <h5>Example payloads</h5>
-<ul>{% for payload in finding.example_payloads %}<li><code>{{ payload }}</code></li>{% endfor %}</ul>
+<ul>{% for payload in finding.example_payloads %}<li><code>{{ payload | e }}</code></li>{% endfor %}</ul>
 {% endif %}
 {% if finding.http_raw_requests %}
 <h5>HTTP raw requests (Burp / ZAP)</h5>
 {% for raw in finding.http_raw_requests %}
-<pre class="http-raw"><code>{{ raw }}</code></pre>
+<pre class="http-raw"><code>{{ raw | e }}</code></pre>
 {% endfor %}
 {% endif %}
-{% if finding.exploitation_conditions %}<h5>Conditions</h5><p>{{ finding.exploitation_conditions }}</p>{% endif %}
-{% if finding.remediation %}<h5>Remediation</h5><p>{{ finding.remediation }}</p>{% endif %}
+{% if finding.exploitation_conditions %}<h5>Conditions</h5><p>{{ finding.exploitation_conditions | e }}</p>{% endif %}
+{% if finding.remediation %}<h5>Remediation</h5><p>{{ finding.remediation | e }}</p>{% endif %}
 {% if finding.secure_code_example %}
 <h5>Secure example</h5>
-<pre><code>{{ finding.secure_code_example }}</code></pre>
+<pre><code>{{ finding.secure_code_example | e }}</code></pre>
 {% endif %}
 </div>
 </details>

--- a/oasis/templates/reports/executive_summary_from_json.html.j2
+++ b/oasis/templates/reports/executive_summary_from_json.html.j2
@@ -30,10 +30,10 @@
         <li><a class="report-toc-btn" href="#exec-models"><span class="report-toc-icon" aria-hidden="true">🤖</span><span class="report-toc-label">Models used</span></a></li>
         <li><a class="report-toc-btn" href="#exec-vuln-summary"><span class="report-toc-icon" aria-hidden="true">🛡️</span><span class="report-toc-label">Vulnerability summary</span></a></li>
         <li><a class="report-toc-btn" href="#exec-similarity-tiers"><span class="report-toc-icon" aria-hidden="true">📊</span><span class="report-toc-label">Tier counts</span></a></li>
+        <li><a class="report-toc-btn" href="#assistant"><span class="report-toc-icon" aria-hidden="true">💬</span><span class="report-toc-label">Assistant</span></a></li>
       </ul>
     </nav>
-
-    {{ macros.render_return_to_toc() }}
+    <div class="executive-preview-before-overview" data-oasis-exec-before-overview="1"></div>
 
     {{ macros.render_executive_kpi_grid(payload.overview) }}
 

--- a/oasis/templates/reports/executive_summary_from_json.html.j2
+++ b/oasis/templates/reports/executive_summary_from_json.html.j2
@@ -1,39 +1,81 @@
 {% import "reports/_macros.html.j2" as macros %}
 {% set preview = preview if preview is defined else {} %}
-<article class="report-executive-summary">
-  {{ macros.render_codebase_warning_banner(preview) }}
-  <h1>{{ payload.title }}</h1>
-  <p><strong>Generated at:</strong> {{ payload.generated_at }}</p>
-  {% if payload.project %}
-  <p><strong>Project:</strong> {{ payload.project }}</p>
-  {% endif %}
-  {% if payload.analysis_root %}
-  <p><strong>Analysis root:</strong> <code class="report-meta-code">{{ payload.analysis_root }}</code></p>
-  {% endif %}
-  <h2>Models Used</h2>
-  <ul>
-    <li><strong>Deep model:</strong> {{ payload.deep_model }}</li>
-    <li><strong>Small model:</strong> {{ payload.small_model }}</li>
-    <li><strong>Embedding model:</strong> {{ payload.embedding_model }}</li>
-  </ul>
-  <h2>Vulnerability Summary</h2>
-  <ul>
-    {% if payload.vulnerability_summary %}
-    {% for name, count in payload.vulnerability_summary %}
-    <li><strong>{{ name }}</strong>: {{ count }}</li>
-    {% endfor %}
-    {% else %}
-    <li>No vulnerability summary available.</li>
+<div class="executive-preview">
+  <article class="report-executive-summary">
+    {{ macros.render_codebase_warning_banner(preview) }}
+    <h1 id="executive-summary-title">{{ payload.title }}</h1>
+    {% if payload.executive_lead %}
+    <p class="report-executive-lead">{{ payload.executive_lead | e }}</p>
     {% endif %}
-  </ul>
-  <h2>Similarity Tier Counts</h2>
-  <ul>
-    {% if payload.similarity_tier_counts %}
-    {% for tier, count in payload.similarity_tier_counts %}
-    <li><strong>{{ tier }}</strong>: {{ count }}</li>
-    {% endfor %}
-    {% else %}
-    <li>No similarity tier data available.</li>
+    <p><strong>Generated at:</strong> {{ payload.generated_at }}
+      {% if payload.oasis_version %}<span class="report-executive-meta-inline"> · <strong>OASIS</strong> {{ payload.oasis_version }}</span>{% endif %}
+    </p>
+    {% if payload.project %}
+    <p><strong>Project:</strong> {{ payload.project }}</p>
     {% endif %}
-  </ul>
-</article>
+    {% if payload.analysis_root %}
+    <p><strong>Analysis root:</strong> <code class="report-meta-code">{{ payload.analysis_root }}</code></p>
+    {% endif %}
+
+    <nav class="report-toc executive-preview-toc" aria-label="Table of contents">
+      <h2 id="table-of-contents" class="report-toc-title">Table of contents</h2>
+      <ul class="report-toc-list">
+        <li><a class="report-toc-btn" href="#exec-situation"><span class="report-toc-icon" aria-hidden="true">🎯</span><span class="report-toc-label">At a glance</span></a></li>
+        <li><a class="report-toc-btn" href="#exec-guidance"><span class="report-toc-icon" aria-hidden="true">📖</span><span class="report-toc-label">How to read this summary</span></a></li>
+        <li><a class="report-toc-btn" href="#exec-tier-defs"><span class="report-toc-icon" aria-hidden="true">📐</span><span class="report-toc-label">Similarity tiers</span></a></li>
+        <li><a class="report-toc-btn" href="#exec-highlights"><span class="report-toc-icon" aria-hidden="true">⚡</span><span class="report-toc-label">Priority matches</span></a></li>
+        {% if payload.progress_summary %}
+        <li><a class="report-toc-btn" href="#exec-scan-status"><span class="report-toc-icon" aria-hidden="true">⏱️</span><span class="report-toc-label">Scan status</span></a></li>
+        {% endif %}
+        <li><a class="report-toc-btn" href="#exec-models"><span class="report-toc-icon" aria-hidden="true">🤖</span><span class="report-toc-label">Models used</span></a></li>
+        <li><a class="report-toc-btn" href="#exec-vuln-summary"><span class="report-toc-icon" aria-hidden="true">🛡️</span><span class="report-toc-label">Vulnerability summary</span></a></li>
+        <li><a class="report-toc-btn" href="#exec-similarity-tiers"><span class="report-toc-icon" aria-hidden="true">📊</span><span class="report-toc-label">Tier counts</span></a></li>
+      </ul>
+    </nav>
+
+    {{ macros.render_return_to_toc() }}
+
+    {{ macros.render_executive_kpi_grid(payload.overview) }}
+
+    {{ macros.render_executive_guidance_html(payload.guidance_html) }}
+
+    {{ macros.render_executive_tier_definitions_table(payload.tier_definitions) }}
+
+    {{ macros.render_executive_similarity_highlights_table(payload.similarity_rows) }}
+
+    {% if payload.progress_summary %}
+    {{ macros.render_executive_scan_status(payload.progress_summary) }}
+    {% endif %}
+
+    <h2 id="exec-models">Models Used</h2>
+    <ul>
+      <li><strong>Deep model:</strong> {{ payload.deep_model }}</li>
+      <li><strong>Small model:</strong> {{ payload.small_model }}</li>
+      <li><strong>Embedding model:</strong> {{ payload.embedding_model }}</li>
+    </ul>
+    {{ macros.render_return_to_toc() }}
+
+    <h2 id="exec-vuln-summary">Vulnerability Summary</h2>
+    <ul>
+      {% if payload.vulnerability_summary %}
+      {% for name, count in payload.vulnerability_summary %}
+      <li><strong>{{ name }}</strong>: {{ count }} embedding match(es)</li>
+      {% endfor %}
+      {% else %}
+      <li>No vulnerability summary available.</li>
+      {% endif %}
+    </ul>
+    {{ macros.render_return_to_toc() }}
+
+    <h2 id="exec-similarity-tiers">Similarity Tier Counts</h2>
+    <ul>
+      {% if payload.similarity_tier_counts %}
+      {% for tier, count in payload.similarity_tier_counts %}
+      <li><strong>{{ tier }}</strong>: {{ count }}</li>
+      {% endfor %}
+      {% else %}
+      <li>No similarity tier data available.</li>
+      {% endif %}
+    </ul>
+  </article>
+</div>

--- a/oasis/web.py
+++ b/oasis/web.py
@@ -155,8 +155,8 @@ from .helpers.assistant.think.think_parse import (
 from .helpers.assistant.prompt.context_budget import assistant_total_system_budget_chars
 from .helpers.assistant.scan.scan_aggregate import model_directory_from_security_report_file
 from .helpers.dashboard.severity_filter import (
-    empty_severity_histogram,
-    merge_severity_histogram_for_report,
+    empty_severity_finding_totals,
+    merge_severity_finding_totals_for_report,
     parse_severity_filter_param,
     report_passes_dashboard_severity_filter,
 )
@@ -2972,7 +2972,7 @@ class WebServer:
             "formats": {},
             "dates": {},
             "projects": {},
-            "severities": empty_severity_histogram(),
+            "severity_finding_totals": empty_severity_finding_totals(),
             "risk_summary": {
                 "total_findings": 0,
                 "critical": 0,
@@ -2986,7 +2986,7 @@ class WebServer:
         for report in reports_to_analyze:
             if report["format"] == "json":
                 self._update_stats_for_report(stats, report)
-                merge_severity_histogram_for_report(stats["severities"], report)
+                merge_severity_finding_totals_for_report(stats["severity_finding_totals"], report)
 
             # count all available formats
             fmt = report["format"]

--- a/oasis/web.py
+++ b/oasis/web.py
@@ -1480,8 +1480,6 @@ class WebServer:
                 return True
             filtered_reports = list(self.filter_reports(**filter_kwargs))
             allowed_paths = self._allowed_paths_for_filtered_reports(filtered_reports)
-            if allowed_paths is None:
-                return True
             try:
                 rel_path = WebServer._normalize_dashboard_relative_report_path(
                     resolved_path.relative_to(security_root).as_posix()
@@ -1565,7 +1563,11 @@ class WebServer:
                 if not isinstance(payload, dict):
                     return jsonify({'error': 'Invalid JSON report payload'}), 422
                 severity_tiers = parse_severity_filter_param(request.args.get('severity', ''))
-                payload = self._filter_vulnerability_payload_by_severity_tiers(payload, severity_tiers)
+                payload = self._filter_vulnerability_payload_by_severity_tiers(
+                    payload,
+                    severity_tiers,
+                    rewrite_stats_totals=True,
+                )
                 return jsonify(payload)
             except Exception:
                 return self._report_preview_error_response("Error while generating JSON report preview")
@@ -1623,7 +1625,7 @@ class WebServer:
                     return jsonify(meta)
                 filtered_reports = list(self.filter_reports(**filter_kwargs))
                 allowed_paths = self._allowed_paths_for_filtered_reports(filtered_reports)
-                if allowed_paths is None:
+                if not allowed_paths:
                     return jsonify({'severity_counts': {}, 'vulnerability_reports': []})
 
                 model_rel_prefix = WebServer._normalize_dashboard_relative_report_path(
@@ -2112,7 +2114,11 @@ class WebServer:
                 if not isinstance(payload, dict):
                     return jsonify({'error': 'Invalid JSON report payload'}), 422
                 severity_tiers = parse_severity_filter_param(request.args.get('severity', ''))
-                payload = self._filter_vulnerability_payload_by_severity_tiers(payload, severity_tiers)
+                payload = self._filter_vulnerability_payload_by_severity_tiers(
+                    payload,
+                    severity_tiers,
+                    rewrite_stats_totals=True,
+                )
 
                 ar_raw = payload.get("analysis_root")
                 ar_text = ar_raw.strip() if isinstance(ar_raw, str) else None
@@ -3135,9 +3141,9 @@ class WebServer:
     @staticmethod
     def _allowed_paths_for_filtered_reports(
         filtered_reports: Iterable[Dict[str, Any]] | None,
-    ) -> set[str] | None:
+    ) -> set[str]:
         if not filtered_reports:
-            return None
+            return set()
         allowed_paths: set[str] = set()
         for report in filtered_reports:
             report_path = WebServer._normalize_dashboard_relative_report_path(report.get("path"))
@@ -3172,7 +3178,10 @@ class WebServer:
 
     @staticmethod
     def _filter_vulnerability_payload_by_severity_tiers(
-        payload: Dict[str, Any], tiers: Tuple[str, ...]
+        payload: Dict[str, Any],
+        tiers: Tuple[str, ...],
+        *,
+        rewrite_stats_totals: bool = False,
     ) -> Dict[str, Any]:
         """Filter canonical vulnerability payload findings to selected severity tiers."""
         if not tiers:
@@ -3230,17 +3239,18 @@ class WebServer:
         stats = data.get("stats")
         original_stats = dict(stats) if isinstance(stats, dict) else {}
         stats_copy = dict(stats) if isinstance(stats, dict) else {}
-        stats_copy["critical_risk"] = sev_counts["critical"]
-        stats_copy["high_risk"] = sev_counts["high"]
-        stats_copy["medium_risk"] = sev_counts["medium"]
-        stats_copy["low_risk"] = sev_counts["low"]
-        # Keep totals aligned with kept findings even when non-canonical severities are present.
-        stats_copy["total_findings"] = total_findings_count
-        stats_copy["files_analyzed"] = len(filtered_files)
-        # Compatibility note: ``potential_findings`` remains chunk-granular (historical behavior).
-        stats_copy["potential_findings"] = potential_chunk_count
+        if rewrite_stats_totals:
+            stats_copy["critical_risk"] = sev_counts["critical"]
+            stats_copy["high_risk"] = sev_counts["high"]
+            stats_copy["medium_risk"] = sev_counts["medium"]
+            stats_copy["low_risk"] = sev_counts["low"]
+            # Keep totals aligned with kept findings even when non-canonical severities are present.
+            stats_copy["total_findings"] = total_findings_count
+            stats_copy["files_analyzed"] = len(filtered_files)
+            # Compatibility note: ``potential_findings`` remains chunk-granular (historical behavior).
+            stats_copy["potential_findings"] = potential_chunk_count
         data["stats"] = stats_copy
-        if original_stats:
+        if rewrite_stats_totals and original_stats:
             data["stats_unfiltered"] = original_stats
         return data
 

--- a/oasis/web.py
+++ b/oasis/web.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+from collections.abc import Iterable
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import logging
@@ -73,6 +75,7 @@ from .helpers.dashboard import (
     rewrite_report_preview_anchor_hrefs,
     slice_markdown_section_after_heading,
     socketio_lan_http_origins,
+    strip_report_header_for_web_preview,
 )
 from .helpers.progress import SCAN_PROGRESS_EXTENDED_KEYS, coerce_scan_progress_event_version
 from .report import Report, executive_summary_progress_sidecar_path, is_executive_summary_progress_sidecar
@@ -1470,6 +1473,26 @@ class WebServer:
             # The complete path now includes the timestamp directory
             return send_from_directory(security_dir, filename)
 
+        def _path_allowed_by_active_filters(resolved_path: Path, security_root: Path) -> bool:
+            """True when ``resolved_path`` belongs to the currently filtered dashboard dataset."""
+            filter_kwargs = self._request_dashboard_filter_kwargs(request.args)
+            if not self._has_any_active_dashboard_filter(filter_kwargs):
+                return True
+            filtered_reports = list(self.filter_reports(**filter_kwargs))
+            allowed_paths = self._allowed_paths_for_filtered_reports(filtered_reports)
+            if allowed_paths is None:
+                return True
+            try:
+                rel_path = WebServer._normalize_dashboard_relative_report_path(
+                    resolved_path.relative_to(security_root).as_posix()
+                )
+            except ValueError:
+                return False
+            return rel_path in allowed_paths
+
+        def _filtered_out_preview_response():
+            return jsonify({'error': 'Report path is outside the active filter scope'}), 409
+
         @app.route('/api/report-content/<path:filename>')
         @login_required
         def get_report_content(filename):
@@ -1485,6 +1508,8 @@ class WebServer:
 
                 if not resolved_path.exists() or resolved_path.suffix != '.md':
                     return jsonify({'error': 'File not found or not a markdown file'}), 404
+                if not _path_allowed_by_active_filters(resolved_path, security_root):
+                    return _filtered_out_preview_response()
 
                 rel_path = resolved_path.relative_to(security_root)
                 rel_parts = rel_path.parts
@@ -1529,6 +1554,8 @@ class WebServer:
                             if md_dir is not None:
                                 return jsonify(synthetic_executive_primary_payload(md_dir))
                     return jsonify({'error': 'File not found or not JSON'}), 404
+                if not _path_allowed_by_active_filters(resolved_path, security_root):
+                    return _filtered_out_preview_response()
                 if is_executive_summary_progress_sidecar(resolved_path):
                     return jsonify(
                         {'error': 'Incremental progress sidecar is not a canonical vulnerability report JSON'}
@@ -1537,6 +1564,8 @@ class WebServer:
                     payload = json.load(f)
                 if not isinstance(payload, dict):
                     return jsonify({'error': 'Invalid JSON report payload'}), 422
+                severity_tiers = parse_severity_filter_param(request.args.get('severity', ''))
+                payload = self._filter_vulnerability_payload_by_severity_tiers(payload, severity_tiers)
                 return jsonify(payload)
             except Exception:
                 return self._report_preview_error_response("Error while generating JSON report preview")
@@ -1585,10 +1614,44 @@ class WebServer:
                 model_dir = model_directory_from_security_report_file(security_root, resolved)
                 if model_dir is None:
                     return jsonify({'error': 'Could not resolve model directory'}), 400
-                meta = rollup_severity_counts_from_model_dir(model_dir)
-                meta['vulnerability_reports'] = vulnerability_reports_for_executive_assistant(
-                    model_dir, security_root
-                )
+                filter_kwargs = self._request_dashboard_filter_kwargs(request.args)
+                if not self._has_any_active_dashboard_filter(filter_kwargs):
+                    meta = rollup_severity_counts_from_model_dir(model_dir)
+                    meta['vulnerability_reports'] = vulnerability_reports_for_executive_assistant(
+                        model_dir, security_root
+                    )
+                    return jsonify(meta)
+                filtered_reports = list(self.filter_reports(**filter_kwargs))
+                allowed_paths = self._allowed_paths_for_filtered_reports(filtered_reports)
+                if allowed_paths is None:
+                    return jsonify({'severity_counts': {}, 'vulnerability_reports': []})
+
+                model_rel_prefix = WebServer._normalize_dashboard_relative_report_path(
+                    model_dir.relative_to(security_root).as_posix()
+                ).rstrip("/") + "/"
+                scoped_reports = [
+                    report
+                    for report in filtered_reports
+                    if WebServer._normalize_dashboard_relative_report_path(str(report.get("path") or "")).startswith(
+                        model_rel_prefix
+                    )
+                    and str(report.get("format") or "").lower() == "json"
+                    and str(report.get("vulnerability_type") or "") != "Executive Summary"
+                ]
+                severity_counts = empty_severity_finding_totals()
+                for report in scoped_reports:
+                    merge_severity_finding_totals_for_report(severity_counts, report)
+                vuln_reports = [
+                    item
+                    for item in vulnerability_reports_for_executive_assistant(model_dir, security_root)
+                    if WebServer._normalize_dashboard_relative_report_path(item.get("relative_path"))
+                    in allowed_paths
+                ]
+                meta = {
+                    "severity_counts": severity_counts,
+                    "vulnerability_report_files": len(vuln_reports),
+                    "vulnerability_reports": vuln_reports,
+                }
                 return jsonify(meta)
             except Exception:
                 return self._report_preview_error_response("Error while building executive preview meta")
@@ -2032,6 +2095,8 @@ class WebServer:
                     return jsonify({'error': 'Invalid path'}), 403
                 if not resolved_path.exists() or resolved_path.suffix != '.json':
                     return jsonify({'error': 'File not found or not JSON'}), 404
+                if not _path_allowed_by_active_filters(resolved_path, security_root):
+                    return _filtered_out_preview_response()
                 if is_executive_summary_progress_sidecar(resolved_path):
                     return jsonify(
                         {
@@ -2046,6 +2111,8 @@ class WebServer:
                     payload = json.load(f)
                 if not isinstance(payload, dict):
                     return jsonify({'error': 'Invalid JSON report payload'}), 422
+                severity_tiers = parse_severity_filter_param(request.args.get('severity', ''))
+                payload = self._filter_vulnerability_payload_by_severity_tiers(payload, severity_tiers)
 
                 ar_raw = payload.get("analysis_root")
                 ar_text = ar_raw.strip() if isinstance(ar_raw, str) else None
@@ -2056,11 +2123,16 @@ class WebServer:
                     "codebase_warning_detail": (
                         "" if codebase_ok else CODEBASE_UNAVAILABLE_DETAIL
                     ),
+                    "active_severity_filter": [tier.capitalize() for tier in severity_tiers],
+                    # Internal-only context for executive-summary detail link fallback.
+                    "_security_root": security_root,
+                    "_current_report_path": resolved_path,
                 }
                 html_content = self.report.render_report_html_from_json_payload(
                     payload,
                     preview_context=preview_ctx,
                 )
+                html_content = strip_report_header_for_web_preview(html_content)
                 return jsonify({'content': html_content}), 200
             except Exception:
                 return self._report_preview_error_response("Error while generating HTML preview from canonical JSON report")
@@ -3028,6 +3100,149 @@ class WebServer:
         risk_summary["high"] += report_stats.get("high_risk", 0)
         risk_summary["medium"] += report_stats.get("medium_risk", 0)
         risk_summary["low"] += report_stats.get("low_risk", 0)
+
+    def _request_dashboard_filter_kwargs(self, req_args: Any) -> Dict[str, Any]:
+        """Extract active dashboard filters from request args for preview-scope checks."""
+        return {
+            "model_filter": req_args.get('model', ''),
+            "format_filter": req_args.get('format', ''),
+            "vuln_filter": req_args.get('vulnerability', ''),
+            "severity_filter": req_args.get('severity', ''),
+            "language_filter": req_args.get('language', ''),
+            "project_filter": req_args.get('project', ''),
+            "start_date": req_args.get('start_date', None),
+            "end_date": req_args.get('end_date', None),
+            # Preview-scope checks must match full dashboard scope, not markdown-only date subset.
+            "md_dates_only": False,
+        }
+
+    @staticmethod
+    def _has_any_active_dashboard_filter(filter_kwargs: Dict[str, Any]) -> bool:
+        for key in (
+            "model_filter",
+            "format_filter",
+            "vuln_filter",
+            "severity_filter",
+            "language_filter",
+            "project_filter",
+            "start_date",
+            "end_date",
+        ):
+            if str(filter_kwargs.get(key) or "").strip():
+                return True
+        return False
+
+    @staticmethod
+    def _allowed_paths_for_filtered_reports(
+        filtered_reports: Iterable[Dict[str, Any]] | None,
+    ) -> set[str] | None:
+        if not filtered_reports:
+            return None
+        allowed_paths: set[str] = set()
+        for report in filtered_reports:
+            report_path = WebServer._normalize_dashboard_relative_report_path(report.get("path"))
+            if report_path:
+                allowed_paths.add(report_path)
+            alt = report.get("alternative_formats") or {}
+            if isinstance(alt, dict):
+                for candidate in alt.values():
+                    candidate_path = WebServer._normalize_dashboard_relative_report_path(candidate)
+                    if candidate_path:
+                        allowed_paths.add(candidate_path)
+        return allowed_paths
+
+    @staticmethod
+    def _normalize_dashboard_relative_report_path(path_value: Any) -> str:
+        """Canonicalize report relative paths for filter-scope comparisons."""
+        if not isinstance(path_value, str):
+            return ""
+        raw = path_value.strip()
+        if not raw:
+            return ""
+        if raw.startswith(("/", "\\")):
+            return ""
+        normalized = os.path.normpath(raw.replace("\\", "/")).replace("\\", "/")
+        if normalized in ("", ".", ".."):
+            return ""
+        if normalized.startswith("../"):
+            return ""
+        if normalized.startswith("./"):
+            normalized = normalized[2:]
+        return normalized.lstrip("/")
+
+    @staticmethod
+    def _filter_vulnerability_payload_by_severity_tiers(
+        payload: Dict[str, Any], tiers: Tuple[str, ...]
+    ) -> Dict[str, Any]:
+        """Filter canonical vulnerability payload findings to selected severity tiers."""
+        if not tiers:
+            return payload
+        if str(payload.get("report_type") or "").strip().lower() != "vulnerability":
+            return payload
+        wanted = {str(t or "").strip().lower() for t in tiers if str(t or "").strip()}
+        if not wanted:
+            return payload
+
+        data = deepcopy(payload)
+        files = data.get("files")
+        if not isinstance(files, list):
+            return data
+
+        filtered_files: List[Dict[str, Any]] = []
+        sev_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        total_findings_count = 0
+        potential_chunk_count = 0
+
+        for file_item in files:
+            if not isinstance(file_item, dict):
+                continue
+            chunk_list = file_item.get("chunk_analyses")
+            kept_chunks: List[Dict[str, Any]] = []
+            if isinstance(chunk_list, list):
+                for chunk in chunk_list:
+                    if not isinstance(chunk, dict):
+                        continue
+                    findings = chunk.get("findings")
+                    if not isinstance(findings, list):
+                        continue
+                    kept_findings: List[Dict[str, Any]] = []
+                    for finding in findings:
+                        if not isinstance(finding, dict):
+                            continue
+                        sev = str(finding.get("severity") or "").strip().lower()
+                        if sev in wanted:
+                            kept_findings.append(finding)
+                            total_findings_count += 1
+                            if sev in sev_counts:
+                                sev_counts[sev] += 1
+                    if kept_findings:
+                        chunk_copy = dict(chunk)
+                        chunk_copy["findings"] = kept_findings
+                        kept_chunks.append(chunk_copy)
+                        if bool(chunk_copy.get("potential_vulnerabilities")):
+                            potential_chunk_count += 1
+            if kept_chunks or file_item.get("error"):
+                file_copy = dict(file_item)
+                file_copy["chunk_analyses"] = kept_chunks
+                filtered_files.append(file_copy)
+
+        data["files"] = filtered_files
+        stats = data.get("stats")
+        original_stats = dict(stats) if isinstance(stats, dict) else {}
+        stats_copy = dict(stats) if isinstance(stats, dict) else {}
+        stats_copy["critical_risk"] = sev_counts["critical"]
+        stats_copy["high_risk"] = sev_counts["high"]
+        stats_copy["medium_risk"] = sev_counts["medium"]
+        stats_copy["low_risk"] = sev_counts["low"]
+        # Keep totals aligned with kept findings even when non-canonical severities are present.
+        stats_copy["total_findings"] = total_findings_count
+        stats_copy["files_analyzed"] = len(filtered_files)
+        # Compatibility note: ``potential_findings`` remains chunk-granular (historical behavior).
+        stats_copy["potential_findings"] = potential_chunk_count
+        data["stats"] = stats_copy
+        if original_stats:
+            data["stats_unfiltered"] = original_stats
+        return data
 
     def _update_stats_for_report(self, stats: dict, report: dict) -> None:
         stats["total_reports"] += 1

--- a/tests/test_helpers_dashboard.py
+++ b/tests/test_helpers_dashboard.py
@@ -128,6 +128,44 @@ class TestHelpersDashboard(unittest.TestCase):
         self.assertEqual(fmt, "json")
         self.assertTrue(rel.endswith("/json/sql_injection.json"))
 
+    def test_preferred_detail_raises_when_output_base_dir_missing(self):
+        from types import SimpleNamespace
+
+        report = SimpleNamespace(
+            current_model="embed_model",
+            report_dirs={},
+        )
+        with self.assertRaises(ValueError):
+            preferred_detail_relative_path_and_format(report, "sql_injection")
+
+    def test_preferred_detail_falls_back_from_current_report_path_when_output_base_missing(self):
+        import tempfile
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        from oasis.export.filenames import artifact_filename
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sec = Path(tmp) / "security_reports"
+            model_dir = sec / "proj" / "20260101_120000" / "embed_model"
+            json_dir = model_dir / "json"
+            json_dir.mkdir(parents=True)
+            stem = "sql_injection"
+            detail = json_dir / artifact_filename(stem, "json")
+            detail.write_text("{}", encoding="utf-8")
+            current = json_dir / "_executive_summary.json"
+            current.write_text("{}", encoding="utf-8")
+
+            report = SimpleNamespace(current_model="embed_model", report_dirs={})
+            rel, fmt = preferred_detail_relative_path_and_format(
+                report,
+                stem,
+                security_root=sec,
+                current_report_path=current,
+            )
+            self.assertEqual(fmt, "json")
+            self.assertTrue(rel.endswith("/json/sql_injection.json"))
+
     def test_rewrite_preview_links_relative_pdf_to_reports(self):
         import tempfile
         from pathlib import Path

--- a/tests/test_helpers_dashboard.py
+++ b/tests/test_helpers_dashboard.py
@@ -17,7 +17,7 @@ from oasis.helpers.dashboard import (
 )
 from oasis.helpers.dashboard.json_sibling import json_sibling_for_format_artifact
 from oasis.helpers.dashboard.severity_filter import (
-    merge_severity_histogram_for_report,
+    merge_severity_finding_totals_for_report,
     parse_severity_filter_param,
     report_passes_dashboard_severity_filter,
 )
@@ -75,9 +75,9 @@ class TestHelpersDashboard(unittest.TestCase):
         exec_row = {"format": "json", "vulnerability_type": "Executive Summary", "stats": {}}
         self.assertTrue(report_passes_dashboard_severity_filter(exec_row, ("medium",)))
 
-    def test_merge_severity_histogram_for_report(self):
+    def test_merge_severity_finding_totals_for_report(self):
         hist = {"critical": 0, "high": 0, "medium": 0, "low": 0}
-        merge_severity_histogram_for_report(
+        merge_severity_finding_totals_for_report(
             hist,
             {
                 "format": "json",
@@ -85,7 +85,7 @@ class TestHelpersDashboard(unittest.TestCase):
                 "stats": {"high_risk": 0, "medium_risk": 2, "low_risk": 0, "critical_risk": 0},
             },
         )
-        self.assertEqual(hist["medium"], 1)
+        self.assertEqual(hist["medium"], 2)
         self.assertEqual(hist["high"], 0)
 
     def test_preferred_detail_prefers_existing_json_over_pdf(self):

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -485,6 +485,48 @@ class TestReportSchema(unittest.TestCase):
         self.assertIn("deep-model", html)
         self.assertIn("SQL Injection", html)
         self.assertIn("strong", html)
+        self.assertIn('class="executive-preview"', html)
+        self.assertIn('class="report-toc executive-preview-toc"', html)
+        self.assertIn('id="table-of-contents"', html)
+        self.assertIn('id="exec-models"', html)
+        self.assertIn('href="#exec-vuln-summary"', html)
+        self.assertIn('id="exec-situation"', html)
+        self.assertIn("Security posture at a glance", html)
+        self.assertIn("How to read this executive summary", html)
+        self.assertIn("Priority embedding matches", html)
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_executive_summary_html_rejects_noncanonical_guidance_markdown(self):
+        """HTML rendering must not convert attacker-controlled Markdown from JSON to HTML."""
+        from oasis.config import REPORT
+
+        report = Report(input_path=".", output_format=["md"])
+        malicious = '<script>alert("x")</script>\n\n## Evil'
+        payload = {
+            "report_type": "executive_summary",
+            "title": "Executive Summary",
+            "generated_at": "2026-01-01T00:00:00Z",
+            "model_name": "m",
+            "guidance_markdown": malicious,
+            "vulnerability_summary": {},
+            "similarity_tier_counts": {},
+        }
+        html = report.render_report_html_from_json_payload(payload)
+        self.assertNotIn("<script>", html)
+        self.assertNotIn("Evil", html)
+        self.assertIn("embedding similarity", html.lower())
+
+        trusted = REPORT["EXPLAIN_EXECUTIVE_SUMMARY"].strip()
+        payload["guidance_markdown"] = trusted
+        html_ok = report.render_report_html_from_json_payload(payload)
+        self.assertIn("embedding similarity", html_ok.lower())
+
+        payload["guidance_id"] = "default.v1"
+        payload["guidance_markdown"] = trusted + "\n\n<script>tampered()</script>"
+        html_tampered = report.render_report_html_from_json_payload(payload)
+        self.assertNotIn("<script>", html_tampered)
+        self.assertNotIn("tampered()", html_tampered)
+        self.assertIn("embedding similarity", html_tampered.lower())
 
     @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
     def test_build_executive_summary_json_document_handles_none_deep_model_name(self):
@@ -501,6 +543,13 @@ class TestReportSchema(unittest.TestCase):
 
         self.assertEqual(payload["model_name"], "fallback-model")
         self.assertEqual(payload["deep_model"], "")
+        self.assertEqual(payload.get("schema_version"), 2)
+        self.assertEqual(payload["overview"]["vulnerability_types_count"], 0)
+        self.assertEqual(payload["overview"]["embedding_comparisons_total"], 0)
+        self.assertEqual(payload["overview"]["unique_source_files"], 0)
+        self.assertIn("guidance_markdown", payload)
+        self.assertEqual(len(payload["tier_definitions"]), 3)
+        self.assertEqual(payload["similarity_highlights"], [])
 
     @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
     def test_render_report_html_from_json_payload_rejects_unknown_report_type(self):
@@ -672,8 +721,17 @@ class TestReportSchema(unittest.TestCase):
             self.assertTrue(canon.is_file())
             parsed = json.loads(canon.read_text(encoding="utf-8"))
             self.assertEqual(parsed.get("report_type"), "executive_summary")
+            self.assertEqual(parsed.get("schema_version"), 2)
             self.assertEqual(parsed.get("model_name"), "test-model")
             self.assertEqual(parsed.get("vulnerability_summary"), {"SQL Injection": 1})
+            self.assertEqual(parsed["overview"]["vulnerability_types_count"], 1)
+            self.assertEqual(parsed["overview"]["embedding_comparisons_total"], 1)
+            self.assertEqual(parsed["overview"]["unique_source_files"], 1)
+            self.assertEqual(len(parsed.get("similarity_highlights") or []), 1)
+            hl0 = parsed["similarity_highlights"][0]
+            self.assertEqual(hl0.get("tier_id"), "strong")
+            self.assertIn("tier_description", hl0)
+            self.assertIn("Strong", hl0["tier_description"])
 
             content = "\n".join(captured["report_content"])
             self.assertIn("Scan Progress", content)
@@ -806,7 +864,7 @@ class TestReportSchema(unittest.TestCase):
         self.assertEqual(stats.get("formats"), {})
         self.assertEqual(stats["risk_summary"]["total_findings"], 0)
         self.assertEqual(stats["risk_summary"]["critical"], 0)
-        self.assertEqual(stats.get("severities", {}).get("critical"), 0)
+        self.assertEqual(stats.get("severity_finding_totals", {}).get("critical"), 0)
 
     @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
     def test_executive_summary_notifier_receives_progress_payload(self):

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -490,10 +490,121 @@ class TestReportSchema(unittest.TestCase):
         self.assertIn('id="table-of-contents"', html)
         self.assertIn('id="exec-models"', html)
         self.assertIn('href="#exec-vuln-summary"', html)
+        self.assertIn('href="#assistant"', html)
         self.assertIn('id="exec-situation"', html)
         self.assertIn("Security posture at a glance", html)
         self.assertIn("How to read this executive summary", html)
         self.assertIn("Priority embedding matches", html)
+        self.assertIn('data-oasis-exec-before-overview="1"', html)
+        self.assertLess(
+            html.find('id="table-of-contents"'),
+            html.find('id="exec-situation"'),
+        )
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_executive_summary_html_without_output_base_dir_does_not_crash(self):
+        report = Report(input_path=".", output_format=["md"])
+        payload = {
+            "report_type": "executive_summary",
+            "title": "Executive Summary",
+            "generated_at": "2026-01-01T00:00:00Z",
+            "model_name": "deep-model",
+            "deep_model": "deep-model",
+            "small_model": "scan-model",
+            "embedding_model": "embed-model",
+            "vulnerability_summary": {"SQL Injection": 1},
+            "similarity_tier_counts": {"strong": 1, "moderate": 0, "weak": 0},
+            "similarity_highlights": [
+                {
+                    "tier_id": "strong",
+                    "vuln_type": "SQL Injection",
+                    "file_path": "app.py",
+                    "similarity_score": 0.95,
+                }
+            ],
+        }
+
+        html = report.render_report_html_from_json_payload(payload)
+        self.assertIn("Executive Summary", html)
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_executive_summary_html_builds_detail_link_from_preview_context(self):
+        report = Report(input_path=".", output_format=["md"])
+        with tempfile.TemporaryDirectory() as td:
+            sec = Path(td) / "security_reports"
+            model_dir = sec / "proj" / "20260101_120000" / "embed_model"
+            json_dir = model_dir / "json"
+            json_dir.mkdir(parents=True)
+            (json_dir / "_executive_summary.json").write_text("{}", encoding="utf-8")
+            (json_dir / "sql_injection.json").write_text("{}", encoding="utf-8")
+            current = json_dir / "_executive_summary.json"
+
+            payload = {
+                "report_type": "executive_summary",
+                "title": "Executive Summary",
+                "generated_at": "2026-01-01T00:00:00Z",
+                "model_name": "embed_model",
+                "deep_model": "embed_model",
+                "small_model": "scan-model",
+                "embedding_model": "embed-model",
+                "vulnerability_summary": {"SQL Injection": 1},
+                "similarity_tier_counts": {"strong": 1, "moderate": 0, "weak": 0},
+                "similarity_highlights": [
+                    {
+                        "tier_id": "strong",
+                        "vuln_type": "SQL Injection",
+                        "file_path": "app.py",
+                        "similarity_score": 0.95,
+                    }
+                ],
+            }
+            html = report._render_executive_summary_inner_html(
+                payload,
+                preview_context={
+                    "_security_root": sec.resolve(),
+                    "_current_report_path": current.resolve(),
+                },
+            )
+            self.assertIn("/reports/proj/20260101_120000/embed_model/json/sql_injection.json", html)
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_report_html_from_json_payload_autoescapes_all_modal_templates(self):
+        report = Report(input_path=".", output_format=["md"])
+
+        exec_payload = {
+            "report_type": "executive_summary",
+            "title": "Executive Summary",
+            "generated_at": "2026-01-01T00:00:00Z",
+            "model_name": "deep-model",
+            "deep_model": "deep-model",
+            "small_model": "scan-model",
+            "embedding_model": "embed-model",
+            "project": '<img src=x onerror=alert("xss")>',
+            "vulnerability_summary": {},
+            "similarity_tier_counts": {},
+        }
+        exec_html = report.render_report_html_from_json_payload(exec_payload)
+        self.assertIn("&lt;img src=x onerror=alert", exec_html)
+        self.assertNotIn('<img src=x onerror=alert("xss")>', exec_html)
+
+        audit_payload = {
+            "report_type": "audit",
+            "schema_version": 1,
+            "title": '<script>alert("xss")</script>',
+            "generated_at": "2026-04-28 12:00:00",
+            "language": "en",
+            "project": None,
+            "oasis_version": "0.5.0",
+            "embedding_model": "nomic",
+            "total_files_analyzed": 1,
+            "explain_analysis": "## About\nSafe content.",
+            "audit_metrics": {"count": 1, "avg_score": 0.5, "high": 0, "medium": 1, "low": 0},
+            "vulnerability_statistics": [],
+            "analyses": {},
+        }
+        audit_html = report.render_report_html_from_json_payload(audit_payload)
+        self.assertIn("&lt;script&gt;alert", audit_html)
+        self.assertNotIn('<script>alert("xss")</script>', audit_html)
 
     @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
     def test_executive_summary_html_rejects_noncanonical_guidance_markdown(self):
@@ -556,6 +667,95 @@ class TestReportSchema(unittest.TestCase):
         report = Report(input_path=".", output_format=["md"])
         with self.assertRaises(ValueError):
             report.render_report_html_from_json_payload({"report_type": "unknown"})
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_report_html_from_json_payload_escapes_finding_fields(self):
+        report = Report(input_path=".", output_format=["md"])
+        payload = {
+            "report_type": "vulnerability",
+            "schema_version": 5,
+            "title": "Escaping Regression",
+            "generated_at": "2026-01-01",
+            "model_name": "m1",
+            "vulnerability_name": "Injection",
+            "vulnerability": {"name": "Injection"},
+            "files": [
+                {
+                    "file_path": "test_files/vulnerable.php",
+                    "similarity_score": 0.9,
+                    "chunk_analyses": [
+                        {
+                            "start_line": 1,
+                            "end_line": 10,
+                            "findings": [
+                                {
+                                    "title": "Broken payload rendering",
+                                    "severity": "High",
+                                    "vulnerable_code": "return eval($code);",
+                                    "explanation": "payload closes code tag",
+                                    "example_payloads": [
+                                        "</code></li></ul><code>",
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "file_path": "test_files/safe.java",
+                    "similarity_score": 0.8,
+                    "chunk_analyses": [],
+                },
+            ],
+            "stats": {
+                "critical_risk": 0,
+                "high_risk": 1,
+                "medium_risk": 0,
+                "low_risk": 0,
+                "total_findings": 1,
+                "files_analyzed": 2,
+            },
+        }
+
+        html = report.render_report_html_from_json_payload(payload)
+        self.assertIn("File 2: test_files/safe.java", html)
+        self.assertIn("&lt;/code&gt;&lt;/li&gt;&lt;/ul&gt;&lt;code&gt;", html)
+        self.assertNotIn("</code></li></ul><code>", html)
+
+    @unittest.skipIf(Report is None, "oasis.report dependencies are unavailable")
+    def test_render_report_html_from_json_payload_whitelists_severity_css_suffix(self):
+        report = Report(input_path=".", output_format=["md"])
+        template = report.template_env.get_template("reports/vulnerability_from_json.html.j2")
+        html = template.render(
+            document={
+                "title": "Severity Suffix Safety",
+                "generated_at": "2026-01-01",
+                "model_name": "m1",
+                "vulnerability_name": "Injection",
+                "files": [
+                    {
+                        "file_path": "test_files/vulnerable.php",
+                        "similarity_score": 0.9,
+                        "chunk_analyses": [
+                            {
+                                "findings": [
+                                    {
+                                        "title": "Unexpected severity format",
+                                        "severity": 'high" onclick="alert(1)',
+                                        "vulnerable_code": "return eval($code);",
+                                        "explanation": "test",
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                ],
+                "stats": {"files_analyzed": 1, "total_findings": 1},
+            },
+            preview={},
+        )
+        self.assertIn("report-severity-pill--unknown", html)
+        self.assertNotIn('report-severity-pill--high" onclick=', html)
 
     def test_scan_verdict_accepts_error_value(self):
         verdict = ScanVerdict.model_validate({"verdict": "ERROR"})
@@ -951,6 +1151,70 @@ class TestReportSchema(unittest.TestCase):
             report_file.write_text('{"stats":', encoding="utf-8")
             stats = WebServer._stats_from_json_report_file(report_file)
         self.assertEqual(stats, {})
+
+    @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
+    def test_normalize_dashboard_relative_report_path_handles_separators_and_dot_segments(self):
+        normalize = WebServer._normalize_dashboard_relative_report_path
+        self.assertEqual(
+            normalize(r"./20260101_120000\m1\json\.\auth.json"),
+            "20260101_120000/m1/json/auth.json",
+        )
+        self.assertEqual(
+            normalize("20260101_120000/m1/json/../json/auth.json"),
+            "20260101_120000/m1/json/auth.json",
+        )
+        self.assertEqual(normalize(r"\windows\rooted.json"), "")
+        self.assertEqual(normalize("/unix/rooted.json"), "")
+        self.assertEqual(normalize("../outside.json"), "")
+
+    @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
+    def test_filter_vulnerability_payload_by_severity_tiers_counts_non_canonical_total_findings(self):
+        payload = {
+            "report_type": "vulnerability",
+            "files": [
+                {
+                    "file_path": "x.py",
+                    "chunk_analyses": [
+                        {
+                            "findings": [
+                                {"severity": "High"},
+                                {"severity": "Info"},
+                            ]
+                        }
+                    ],
+                }
+            ],
+            "stats": {"total_findings": 2},
+        }
+        filtered = WebServer._filter_vulnerability_payload_by_severity_tiers(payload, ("high", "info"))
+        self.assertEqual(filtered["stats"]["high_risk"], 1)
+        self.assertEqual(filtered["stats"]["total_findings"], 2)
+        self.assertEqual(filtered["stats_unfiltered"]["total_findings"], 2)
+
+    @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
+    def test_allowed_paths_for_filtered_reports_collects_primary_and_alternatives(self):
+        reports = [
+            {
+                "path": "run_a/model_a/json/a.json",
+                "alternative_formats": {
+                    "md": r".\run_a\model_a\md\a.md",
+                    "html": "/absolute/should_be_rejected.html",
+                },
+            },
+            {
+                "path": "run_a/model_a/json/b.json",
+                "alternative_formats": {},
+            },
+        ]
+        allowed = WebServer._allowed_paths_for_filtered_reports(reports)
+        self.assertEqual(
+            allowed,
+            {
+                "run_a/model_a/json/a.json",
+                "run_a/model_a/md/a.md",
+                "run_a/model_a/json/b.json",
+            },
+        )
 
     @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
     def test_web_update_stats_for_report_aggregates_model_vuln_language_date_and_risk(self):
@@ -1867,6 +2131,33 @@ Not a table line anymore.
             "polling transport should be listed before websocket",
         )
 
+    def test_dashboard_url_with_active_filters_preserves_hash_fragment(self):
+        api_js = (
+            Path(__file__).resolve().parents[1]
+            / "oasis"
+            / "static"
+            / "js"
+            / "dashboard"
+            / "api.js"
+        )
+        content = api_js.read_text(encoding="utf-8")
+        self.assertIn("const hashIndex = rawUrl.indexOf('#')", content)
+        self.assertIn("const hashFragment = hashIndex >= 0 ? rawUrl.slice(hashIndex) : ''", content)
+        self.assertIn("return `${pathPart}${mergedQuery ? `?${mergedQuery}` : ''}${hashFragment}`;", content)
+
+    def test_dashboard_url_with_active_filters_merges_existing_query_with_urlsearchparams(self):
+        api_js = (
+            Path(__file__).resolve().parents[1]
+            / "oasis"
+            / "static"
+            / "js"
+            / "dashboard"
+            / "api.js"
+        )
+        content = api_js.read_text(encoding="utf-8")
+        self.assertIn("const mergedParams = new URLSearchParams(existingQuery)", content)
+        self.assertIn("mergedParams.append(key, value)", content)
+
     def test_dashboard_views_include_audit_comparison_table_markup(self):
         views_js = (
             Path(__file__).resolve().parents[1]
@@ -1882,6 +2173,8 @@ Not a table line anymore.
         self.assertIn("buildAuditComparisonTableHtml", content)
         self.assertIn("DashboardApp.auditComparison.buildTableHtml", content)
         self.assertIn("DashboardApp.modelSelectionBadgeHtml(0)", content)
+        self.assertIn("critical_risk", content)
+        self.assertIn(".replace('${criticalRisk}'", content)
         self.assertIn("data-model", content)
 
     def test_dashboard_utils_define_audit_comparison_builder(self):
@@ -1915,6 +2208,18 @@ Not a table line anymore.
         )
         content = template_html.read_text(encoding="utf-8")
         self.assertIn("${cardClass}", content)
+        self.assertIn("${criticalRisk}", content)
+        self.assertIn("Critical", content)
+
+    def test_report_jinja_autoescape_is_scoped_to_html_like_templates(self):
+        report_py = (
+            Path(__file__).resolve().parents[1]
+            / "oasis"
+            / "report.py"
+        )
+        content = report_py.read_text(encoding="utf-8")
+        self.assertIn('template_name.endswith(".html.j2")', content)
+        self.assertNotIn("select_autoescape(", content)
 
     def test_dashboard_report_grouping_keeps_audit_metrics_payload_fields(self):
         utils_js = (

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -658,6 +658,7 @@ class TestReportSchema(unittest.TestCase):
         self.assertEqual(payload["overview"]["vulnerability_types_count"], 0)
         self.assertEqual(payload["overview"]["embedding_comparisons_total"], 0)
         self.assertEqual(payload["overview"]["unique_source_files"], 0)
+        self.assertEqual(payload["guidance_id"], "default.v1")
         self.assertIn("guidance_markdown", payload)
         self.assertEqual(len(payload["tier_definitions"]), 3)
         self.assertEqual(payload["similarity_highlights"], [])
@@ -1186,10 +1187,42 @@ class TestReportSchema(unittest.TestCase):
             ],
             "stats": {"total_findings": 2},
         }
-        filtered = WebServer._filter_vulnerability_payload_by_severity_tiers(payload, ("high", "info"))
+        filtered = WebServer._filter_vulnerability_payload_by_severity_tiers(
+            payload,
+            ("high", "info"),
+            rewrite_stats_totals=True,
+        )
         self.assertEqual(filtered["stats"]["high_risk"], 1)
         self.assertEqual(filtered["stats"]["total_findings"], 2)
         self.assertEqual(filtered["stats_unfiltered"]["total_findings"], 2)
+
+    @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
+    def test_filter_vulnerability_payload_by_severity_tiers_preserves_stats_without_rewrite(self):
+        payload = {
+            "report_type": "vulnerability",
+            "files": [
+                {
+                    "file_path": "x.py",
+                    "chunk_analyses": [
+                        {
+                            "findings": [
+                                {"severity": "High"},
+                                {"severity": "Low"},
+                            ]
+                        }
+                    ],
+                }
+            ],
+            "stats": {
+                "high_risk": 10,
+                "low_risk": 8,
+                "total_findings": 18,
+            },
+        }
+        filtered = WebServer._filter_vulnerability_payload_by_severity_tiers(payload, ("high",))
+        self.assertEqual(filtered["stats"]["high_risk"], 10)
+        self.assertEqual(filtered["stats"]["total_findings"], 18)
+        self.assertNotIn("stats_unfiltered", filtered)
 
     @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
     def test_allowed_paths_for_filtered_reports_collects_primary_and_alternatives(self):
@@ -1215,6 +1248,10 @@ class TestReportSchema(unittest.TestCase):
                 "run_a/model_a/json/b.json",
             },
         )
+
+    @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
+    def test_allowed_paths_for_filtered_reports_empty_input_returns_empty_set(self):
+        self.assertEqual(WebServer._allowed_paths_for_filtered_reports([]), set())
 
     @unittest.skipIf(WebServer is None, "oasis.web dependencies are unavailable")
     def test_web_update_stats_for_report_aggregates_model_vuln_language_date_and_risk(self):

--- a/tests/test_web_assistant_api.py
+++ b/tests/test_web_assistant_api.py
@@ -1112,6 +1112,11 @@ class TestExecutiveAndAssistantMetaRoutes(unittest.TestCase):
             blocked_payload = json.loads(blocked.get_data(as_text=True))
             self.assertIn("active filter scope", blocked_payload.get("error", ""))
 
+            blocked_none = client.get("/api/report-json/20260101_120000/m1/json/high.json?severity=critical")
+            self.assertEqual(blocked_none.status_code, 409)
+            blocked_none_payload = json.loads(blocked_none.get_data(as_text=True))
+            self.assertIn("active filter scope", blocked_none_payload.get("error", ""))
+
             allowed = client.get("/api/report-json/20260101_120000/m1/json/high.json?severity=high")
             self.assertEqual(allowed.status_code, 200)
             allowed_payload = json.loads(allowed.get_data(as_text=True))

--- a/tests/test_web_assistant_api.py
+++ b/tests/test_web_assistant_api.py
@@ -1032,6 +1032,258 @@ class TestExecutiveAndAssistantMetaRoutes(unittest.TestCase):
             self.assertEqual(data.get("report_type"), "executive_summary")
             self.assertEqual(data.get("model_name"), "from-vuln")
 
+    def test_report_json_respects_active_severity_filter_scope(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            server, _ = self._make_server(base)
+            sec = base / "security_reports"
+            run_json = sec / "20260101_120000" / "m1" / "json"
+            run_json.mkdir(parents=True)
+            low_medium = {
+                "report_type": "vulnerability",
+                "schema_version": 4,
+                "title": "medium",
+                "generated_at": "2026-01-01",
+                "model_name": "m1",
+                "vulnerability_name": "MediumOnly",
+                "files": [
+                    {
+                        "file_path": "sample_medium.py",
+                        "similarity_score": 0.7,
+                        "chunk_analyses": [
+                            {
+                                "start_line": 1,
+                                "end_line": 3,
+                                "findings": [
+                                    {"title": "Only Medium", "severity": "Medium", "vulnerable_code": "x"}
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                "stats": {
+                    "critical_risk": 0,
+                    "high_risk": 0,
+                    "medium_risk": 1,
+                    "low_risk": 0,
+                    "total_findings": 1,
+                },
+            }
+            high_only = {
+                "report_type": "vulnerability",
+                "schema_version": 4,
+                "title": "high",
+                "generated_at": "2026-01-01",
+                "model_name": "m1",
+                "vulnerability_name": "HighOnly",
+                "files": [
+                    {
+                        "file_path": "sample_high.py",
+                        "similarity_score": 0.8,
+                        "chunk_analyses": [
+                            {
+                                "start_line": 1,
+                                "end_line": 3,
+                                "findings": [
+                                    {"title": "Only High", "severity": "High", "vulnerable_code": "x"}
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                "stats": {
+                    "critical_risk": 0,
+                    "high_risk": 1,
+                    "medium_risk": 0,
+                    "low_risk": 0,
+                    "total_findings": 1,
+                },
+            }
+            (run_json / "medium.json").write_text(json.dumps(low_medium), encoding="utf-8")
+            (run_json / "high.json").write_text(json.dumps(high_only), encoding="utf-8")
+
+            app = Flask(__name__)
+            app.secret_key = "t"
+            server.register_routes(app, server, self._no_auth)
+            client = app.test_client()
+
+            blocked = client.get("/api/report-json/20260101_120000/m1/json/medium.json?severity=high")
+            self.assertEqual(blocked.status_code, 409)
+            blocked_payload = json.loads(blocked.get_data(as_text=True))
+            self.assertIn("active filter scope", blocked_payload.get("error", ""))
+
+            allowed = client.get("/api/report-json/20260101_120000/m1/json/high.json?severity=high")
+            self.assertEqual(allowed.status_code, 200)
+            allowed_payload = json.loads(allowed.get_data(as_text=True))
+            self.assertEqual(allowed_payload.get("vulnerability_name"), "HighOnly")
+            high_chunks = allowed_payload.get("files", [{}])[0].get("chunk_analyses", [])
+            self.assertTrue(high_chunks)
+            severities = [
+                finding.get("severity")
+                for chunk in high_chunks
+                for finding in (chunk.get("findings") or [])
+            ]
+            self.assertEqual(severities, ["High"])
+
+    def test_report_html_filters_non_matching_findings_by_severity(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            server, _ = self._make_server(base)
+            sec = base / "security_reports"
+            run_json = sec / "20260101_140000" / "m1" / "json"
+            run_json.mkdir(parents=True)
+            payload = {
+                "report_type": "vulnerability",
+                "schema_version": 5,
+                "title": "Authentication Issues Security Analysis",
+                "generated_at": "2026-01-01",
+                "model_name": "m1",
+                "vulnerability_name": "Authentication Issues",
+                "vulnerability": {"name": "Authentication Issues"},
+                "files": [
+                    {
+                        "file_path": "test_files/sample.py",
+                        "similarity_score": 0.9,
+                        "chunk_analyses": [
+                            {
+                                "start_line": 1,
+                                "end_line": 5,
+                                "findings": [
+                                    {"title": "Critical Finding", "severity": "Critical", "vulnerable_code": "x"},
+                                    {"title": "Medium Finding", "severity": "Medium", "vulnerable_code": "y"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+                "stats": {
+                    "critical_risk": 1,
+                    "high_risk": 0,
+                    "medium_risk": 1,
+                    "low_risk": 0,
+                    "total_findings": 2,
+                    "files_analyzed": 1,
+                },
+            }
+            (run_json / "authentication_issues.json").write_text(json.dumps(payload), encoding="utf-8")
+
+            app = Flask(__name__)
+            app.secret_key = "t"
+            server.register_routes(app, server, self._no_auth)
+            client = app.test_client()
+
+            response = client.get(
+                "/api/report-html?path=20260101_140000/m1/json/authentication_issues.json&severity=critical"
+            )
+            self.assertEqual(response.status_code, 200)
+            html_payload = json.loads(response.get_data(as_text=True))
+            html = html_payload.get("content", "")
+            self.assertIn("Active severity filter:", html)
+            self.assertIn("Critical", html)
+            self.assertIn("Critical Finding", html)
+            self.assertNotIn("Medium Finding", html)
+            self.assertIn("report-severity-pill--critical", html)
+            self.assertNotIn('class="report-header"', html)
+
+    def test_executive_preview_meta_respects_active_severity_filter_scope(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            server, _ = self._make_server(base)
+            sec = base / "security_reports"
+            run_json = sec / "20260101_130000" / "m_exec" / "json"
+            run_md = sec / "20260101_130000" / "m_exec" / "md"
+            run_json.mkdir(parents=True)
+            run_md.mkdir(parents=True)
+            exec_js = {
+                "report_type": "executive_summary",
+                "schema_version": 1,
+                "model_name": "m-exec",
+                "title": "exec",
+            }
+            medium_only = {
+                "report_type": "vulnerability",
+                "schema_version": 4,
+                "title": "medium",
+                "generated_at": "2026-01-01",
+                "model_name": "m-exec",
+                "vulnerability_name": "OnlyMedium",
+                "files": [{"file_path": "app.py"}],
+                "stats": {
+                    "critical_risk": 0,
+                    "high_risk": 0,
+                    "medium_risk": 2,
+                    "low_risk": 0,
+                    "total_findings": 2,
+                },
+            }
+            (run_json / "_executive_summary.json").write_text(json.dumps(exec_js), encoding="utf-8")
+            (run_json / "vuln_medium.json").write_text(json.dumps(medium_only), encoding="utf-8")
+            (run_md / "_executive_summary.md").write_text("# Executive\n", encoding="utf-8")
+
+            app = Flask(__name__)
+            app.secret_key = "t"
+            server.register_routes(app, server, self._no_auth)
+            client = app.test_client()
+
+            blocked = client.get(
+                "/api/executive-preview-meta?path=20260101_130000/m_exec/md/_executive_summary.md&severity=high"
+            )
+            self.assertEqual(blocked.status_code, 200)
+            blocked_payload = json.loads(blocked.get_data(as_text=True))
+            self.assertEqual(blocked_payload.get("vulnerability_report_files"), 0)
+            self.assertEqual(blocked_payload.get("severity_counts", {}).get("high"), 0)
+
+    def test_executive_preview_meta_tolerates_malformed_filtered_report_entries(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            server, _ = self._make_server(base)
+            sec = base / "security_reports"
+            run_json = sec / "20260101_150000" / "m_exec" / "json"
+            run_md = sec / "20260101_150000" / "m_exec" / "md"
+            run_json.mkdir(parents=True)
+            run_md.mkdir(parents=True)
+            exec_js = {
+                "report_type": "executive_summary",
+                "schema_version": 1,
+                "model_name": "m-exec",
+                "title": "exec",
+            }
+            vuln_js = {
+                "report_type": "vulnerability",
+                "schema_version": 4,
+                "title": "high",
+                "generated_at": "2026-01-01",
+                "model_name": "m-exec",
+                "vulnerability_name": "HighOnly",
+                "files": [{"file_path": "app.py"}],
+                "stats": {"critical_risk": 0, "high_risk": 1, "medium_risk": 0, "low_risk": 0, "total_findings": 1},
+            }
+            (run_json / "_executive_summary.json").write_text(json.dumps(exec_js), encoding="utf-8")
+            (run_json / "vuln_high.json").write_text(json.dumps(vuln_js), encoding="utf-8")
+            (run_md / "_executive_summary.md").write_text("# Executive\n", encoding="utf-8")
+
+            original_filter_reports = server.filter_reports
+
+            def _patched_filter_reports(**kwargs):
+                rows = list(original_filter_reports(**kwargs))
+                rows.append({"path": None, "format": "json", "vulnerability_type": None})
+                rows.append({"path": 123, "format": "json", "vulnerability_type": 7})
+                return rows
+
+            server.filter_reports = _patched_filter_reports
+
+            app = Flask(__name__)
+            app.secret_key = "t"
+            server.register_routes(app, server, self._no_auth)
+            client = app.test_client()
+
+            resp = client.get(
+                "/api/executive-preview-meta?path=20260101_150000/m_exec/md/_executive_summary.md&severity=high"
+            )
+            self.assertEqual(resp.status_code, 200)
+            payload = json.loads(resp.get_data(as_text=True))
+            self.assertEqual(payload.get("severity_counts", {}).get("high"), 1)
+
     def test_assistant_chat_aggregate_without_executive_json_on_disk(self):
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)


### PR DESCRIPTION
## Summary

Improve executive summary report schema and dashboard previews, aligning backend filtering, HTML rendering, and frontend behaviors around severity-aware report views.

New Features:
- Expose richer executive summary metadata in canonical JSON, including overview KPIs, guidance content, tier definitions, and similarity highlight rows used by HTML previews and the dashboard.
- Add reusable executive-summary helpers and Jinja macros to render KPI grids, similarity tier tables, highlight tables, and scan status sections in report previews.
- Introduce a utility to append active dashboard filters to API URLs so report content, JSON, HTML previews, and executive meta requests respect the current filter state.

Bug Fixes:
- Ensure report and assistant HTML previews are safely auto-escaped, including finding details, example payloads, and attacker-controlled guidance content, to prevent XSS in the dashboard.
- Prevent dashboard previews from loading reports outside the active filter scope and handle malformed filtered report entries without crashing executive preview metadata aggregation.
- Fix severity-tier CSS handling so malformed severities fall back to a safe class and non-canonical counters no longer corrupt severity finding totals or stats.

Enhancements:
- Tighten coupling between dashboard filters and preview APIs by scoping accessible report paths and applying severity filters directly to canonical vulnerability JSON before HTML rendering.
- Refine executive preview behavior so charts, metadata rollups, and assistant links use filtered model-specific report sets and updated severity-finding totals.
- Update dashboard cards, list views, and filters to surface critical-risk counts and to consume the renamed severity_finding_totals stats field for clearer semantics.
- Improve assistant verdict and chat model handling by normalizing summary and model strings and by matching model families more robustly.
- Scope Jinja autoescaping to HTML-like templates while explicitly escaping freeform fields in report macros, and strip redundant report headers from web previews for a cleaner modal layout.

Tests:
- Extend regression coverage for executive summary JSON schema v2, HTML rendering, escaping behavior, dashboard filtering and path normalization, severity counting, and API URL construction with active filters.